### PR TITLE
Test-TargetResource returning non-boolean value.

### DIFF
--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -220,6 +220,8 @@ function Test-TargetResource
         Write-Verbose -Message "Checking if workgroup name is $WorkGroupName"
         return ($WorkGroupName -eq (gwmi WIN32_ComputerSystem).WorkGroup)
     }
+
+    return $true
 }
 
 function ValidateDomainOrWorkGroup($DomainName, $WorkGroupName)


### PR DESCRIPTION
If only passing in the $Name parameter to Test-TargetResource, the only
required parameter, and $Name –eq $env:COMPUTERNAME, you drop to the
bottom of the function and the function completes without returning a
bool, causing an error.

Since all false cases are covered with existing return, a true return
was added to the end of the function.