### PR TITLE
New resource xHostFileEntry

### DIFF
--- a/DSCResources/MSFT_xHostFileEntry/MSFT_xHostFileEntry.psm1
+++ b/DSCResources/MSFT_xHostFileEntry/MSFT_xHostFileEntry.psm1
@@ -1,0 +1,126 @@
+function Get-TargetResource
+{
+    [OutputType([System.Collections.Hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $HostName,
+        
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $IPAddress,
+        
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $Ensure = "Present"
+    )
+    $hosts = Get-Content "$env:windir\System32\drivers\etc\hosts"
+    $allHosts = $hosts `
+           | Where-Object { [System.String]::IsNullOrEmpty($_) -eq $false -and $_.StartsWith('#') -eq $false } `
+           | ForEach-Object { 
+                $data = $_ -split '\s+'
+                return @{
+                    Host = $data[1]
+                    IP = $data[0]
+                }
+        } | Select-Object @{Name="Host";Expression={$_.Host}}, @{Name="IP";Expression={$_.IP}}
+        
+    $hostEntry = $allHosts | Where-Object { $_.Host -eq $HostName }
+    
+    if ($hostEntry -eq $null) 
+    {
+        return @{
+            HostName = $HostName
+            IPAddress = $null
+            Ensure = "Absent"
+        }
+    }
+    else 
+    {
+        return @{
+            HostName = $hostEntry.Host
+            IPAddress = $hostEntry.IP
+            Ensure = "Present"
+        }
+    }
+}
+
+function Set-TargetResource
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $HostName,
+        
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $IPAddress,
+        
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $Ensure = "Present"
+    )
+    
+    $currentValues = Get-TargetResource @PSBoundParameters
+    
+    if ($Ensure -eq "Present" -and $PSBoundParameters.ContainsKey("IPAddress") -eq $false) 
+    {
+        throw "Unable to ensure a host entry is present without a corresponding IP address. " + `
+              "Please add the 'IPAddress' property and run this resource again."
+        return
+    }
+    
+    if ($currentValues.Ensure -eq "Absent" -and $Ensure -eq "Present")
+    {
+        Write-Verbose -Message "Creating new host entry for '$HostName'"
+        Add-Content "$env:windir\System32\drivers\etc\hosts" "`r`n$IPAddress`t$HostName"
+    }
+    else 
+    {
+        $hosts = Get-Content "$env:windir\System32\drivers\etc\hosts"
+        $replace = $hosts | Where-Object { $_ -like "*$HostName" }
+        if ($currentValues.Ensure -eq "Present" -and $Ensure -eq "Present")
+        {
+            Write-Verbose -Message "Updating existing host entry for '$HostName'"
+            $hosts = $hosts -replace $replace, "$IPAddress`t$HostName"
+        }
+        if ($Ensure -eq "Absent")
+        {
+            Write-Verbose -Message "Removing host entry for '$HostName'"
+            $hosts = $hosts -replace $replace, ""
+        }
+        $hosts | Set-Content "$env:windir\System32\drivers\etc\hosts"
+    }
+}
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $HostName,
+        
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $IPAddress,
+        
+        [Parameter(Mandatory = $false)]
+        [System.String]
+        $Ensure = "Present"
+    )
+    
+    $currentValues = Get-TargetResource @PSBoundParameters
+    
+    if ($Ensure -ne $currentValues.Ensure) 
+    {
+        return $false
+    }
+   
+    if ($Ensure -eq "Present" -and $IPAddress -ne $currentValues.IPAddress) 
+    {
+        return $false
+    }
+    return $true
+}
+

--- a/DSCResources/MSFT_xHostFileEntry/MSFT_xHostFileEntry.psm1
+++ b/DSCResources/MSFT_xHostFileEntry/MSFT_xHostFileEntry.psm1
@@ -12,6 +12,7 @@ function Get-TargetResource
         
         [Parameter(Mandatory = $false)]
         [System.String]
+        [ValidateSet("Present","Absent")]
         $Ensure = "Present"
     )
     $hosts = Get-Content "$env:windir\System32\drivers\etc\hosts"
@@ -58,6 +59,7 @@ function Set-TargetResource
         
         [Parameter(Mandatory = $false)]
         [System.String]
+        [ValidateSet("Present","Absent")]
         $Ensure = "Present"
     )
     
@@ -107,6 +109,7 @@ function Test-TargetResource
         
         [Parameter(Mandatory = $false)]
         [System.String]
+        [ValidateSet("Present","Absent")]
         $Ensure = "Present"
     )
     

--- a/DSCResources/MSFT_xHostFileEntry/MSFT_xHostFileEntry.schema.mof
+++ b/DSCResources/MSFT_xHostFileEntry/MSFT_xHostFileEntry.schema.mof
@@ -1,0 +1,8 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xHostFileEntry")]
+class MSFT_xHostFileEntry : OMI_BaseResource
+{
+    [Key, Description("The host name to check the local host file for")] string HostName;
+    [Write, Description("The IP address that the host entry should be pointing to if the entry should exist")] string IPAddress;
+    [Write, Description("Present if the host entry should exist, Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure; 
+};
+

--- a/Examples/Sample_xHostFileEntryAdd.ps1
+++ b/Examples/Sample_xHostFileEntryAdd.ps1
@@ -1,0 +1,21 @@
+configuration Sample_xHostFileEntryAdd
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName xComputerManagement
+
+    Node $NodeName
+    {
+        xHostFileEntry Contoso
+        {
+          HostName = "www.contoso.com"
+          IPAddress = "127.0.0.1"
+        }
+    }
+}
+
+Sample_xHostFileEntryAdd
+Start-DscConfiguration -Path Sample_xHostFileEntryAdd -Wait -Verbose -Force

--- a/Examples/Sample_xHostFileEntryRemove.ps1
+++ b/Examples/Sample_xHostFileEntryRemove.ps1
@@ -1,0 +1,21 @@
+configuration Sample_xHostFileEntryRemove
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName xComputerManagement
+
+    Node $NodeName
+    {
+        xHostFileEntry Contoso
+        {
+          HostName = "www.contoso.com"
+          Ensure = "Absent"
+        }
+    }
+}
+
+Sample_xHostFileEntryRemove
+Start-DscConfiguration -Path Sample_xHostFileEntryRemove -Wait -Verbose -Force

--- a/README.md
+++ b/README.md
@@ -52,11 +52,19 @@ xOfflineDomainJoin resource is a [Single Instance](https://msdn.microsoft.com/en
 * IsSingleInstance: Must be set to 'Yes'. Required.
 * RequestFile: The full path to the Offline Domain Join request file. Required.
 
+## xHostFileEntry
+xHostFileEntry is used to manage individual entries in the local machines host file.
+
+* HostName: The host name to validate (e.g. www.contoso.com)
+* IPAddress: The IP address the entry should be set to - optional if Ensure is set to absent
+* Ensure: "Present" ensures the entry exists, "Absent" ensures that the entry doesn't exist - optional, defaults to "Present"
+
 ## Versions
 
 ### Unreleased
 * Added the following resources:
     * MSFT_xOfflineDomainJoin resource to join computers to an AD Domain using an Offline Domain Join request file.
+    * MSFT_xHostFileEntry resource to managed host entries on the local machine
 * MSFT_xOfflineDomainJoin: Corrected localizedData.DomainAlreadyJoinedhMessage name.
 * xComputer: Changed credential generation code in tests to avoid triggering PSSA rule PSAvoidUsingConvertToSecureStringWithPlainText.
              Renamed unit test file to match the name of Resource file.
@@ -335,6 +343,61 @@ configuration Sample_xOfflineDomainJoin
 Sample_xOfflineDomainJoin
 Start-DscConfiguration -Path Sample_xOfflineDomainJoin -Wait -Verbose -Force
 ```
+
+### Add a new host file entry
+This example will add a new host file entry to the local machine.
+
+```powershell
+configuration Sample_xHostFileEntryAdd
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName xComputerManagement
+
+    Node $NodeName
+    {
+        xHostFileEntry Contoso
+        {
+          HostName = "www.contoso.com"
+          IPAddress = "127.0.0.1"
+        }
+    }
+}
+
+Sample_xHostFileEntryAdd
+Start-DscConfiguration -Path Sample_xHostFileEntryAdd -Wait -Verbose -Force
+```
+
+### Remove a host file entry
+This example will remove a host file entry from the local machine.
+
+```powershell
+configuration Sample_xHostFileEntryRemove
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName xComputerManagement
+
+    Node $NodeName
+    {
+        xHostFileEntry Contoso
+        {
+          HostName = "www.contoso.com"
+          Ensure = "Absent"
+        }
+    }
+}
+
+Sample_xHostFileEntryRemove
+Start-DscConfiguration -Path Sample_xHostFileEntryRemove -Wait -Verbose -Force
+```
+
 
 ## Contributing
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).

--- a/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
@@ -6,4 +6,4 @@ Configuration xHostFileEntry_Add {
         IPAddress = "192.168.0.156"
     }
 }
-            
+

--- a/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
@@ -30,3 +30,14 @@ Configuration xHostFileEntry_Remove {
         }    
     }
 }
+
+Configuration xHostFileEntry_AlreadyGone {
+    Import-DscResource -ModuleName xComputerManagement
+    
+    node "localhost" {
+        xHostFileEntry TestAdd {
+            HostName = "www.notreallyawebsiteatall.com"
+            Ensure = "Absent"
+        }    
+    }
+}

--- a/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
@@ -1,0 +1,9 @@
+Configuration xHostFileEntry_Add {
+    Import-DscResource -ModuleName xComputerManagement
+    
+    xHostFileEntry TestAdd {
+        HostName = "www.contoso.com"
+        IPAddress = "192.168.0.156"
+    }
+}
+            

--- a/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
@@ -1,9 +1,11 @@
 Configuration xHostFileEntry_Add {
     Import-DscResource -ModuleName xComputerManagement
     
-    xHostFileEntry TestAdd {
-        HostName = "www.contoso.com"
-        IPAddress = "192.168.0.156"
+    node "localhost" {
+        xHostFileEntry TestAdd {
+            HostName = "www.contoso.com"
+            IPAddress = "192.168.0.156"
+        }    
     }
 }
 

--- a/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Config.ps1
@@ -9,3 +9,24 @@ Configuration xHostFileEntry_Add {
     }
 }
 
+Configuration xHostFileEntry_Edit {
+    Import-DscResource -ModuleName xComputerManagement
+    
+    node "localhost" {
+        xHostFileEntry TestAdd {
+            HostName = "www.contoso.com"
+            IPAddress = "192.168.0.155"
+        }    
+    }
+}
+
+Configuration xHostFileEntry_Remove {
+    Import-DscResource -ModuleName xComputerManagement
+    
+    node "localhost" {
+        xHostFileEntry TestAdd {
+            HostName = "www.contoso.com"
+            Ensure = "Absent"
+        }    
+    }
+}

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -21,44 +21,40 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     #region Pester Tests
-
-    InModuleScope $Global:DSCResourceName {
-
-        Describe $Global:DSCResourceName {
+    Describe $Global:DSCResourceName {
+        
+        Context "A host entry doesn't exist, and should" {
             
-            Context "A host entry doesn't exist, and should" {
-                
-                Configuration xHostFileEntry_Add {
-                    node localhost {
-                        xHostFileEntry TestAdd {
-                            HostName = "www.contoso.com"
-                            IPAddress = "192.168.0.156"
-                        }
+            Configuration xHostFileEntry_Add {
+                node localhost {
+                    xHostFileEntry TestAdd {
+                        HostName = "www.contoso.com"
+                        IPAddress = "192.168.0.156"
                     }
                 }
-                
-                It "should compile a MOF file without error" {
-                    {
-                        xHostFileEntry_Add -OutputPath (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add")
-                    } | Should Not Throw
-                }
-                
-                It "should apply the MOF correctly" {
-                    {
-                        Start-DscConfiguration -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") -ComputerName localhost -Wait -Verbose -Force
-                    } | Should Not Throw
-                }
-                
-                It "should return a compliant state after being applied" {
-                    Test-DscConfiguration -ComputerName localhost -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") | Should Be $true
-                }
-                
-                It "should return Get-DscConfiguration without error" {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
-                }
+            }
+            
+            It "should compile a MOF file without error" {
+                {
+                    xHostFileEntry_Add -OutputPath (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add")
+                } | Should Not Throw
+            }
+            
+            It "should apply the MOF correctly" {
+                {
+                    Start-DscConfiguration -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") -ComputerName localhost -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+            
+            It "should return a compliant state after being applied" {
+                Test-DscConfiguration -ComputerName localhost -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") | Should Be $true
+            }
+            
+            It "should return Get-DscConfiguration without error" {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
         }
-    } #end InModuleScope $DSCResourceName
+    }
     #endregion
 }
 finally

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -1,0 +1,69 @@
+$Global:DSCModuleName      = 'xComputerManagement'
+$Global:DSCResourceName    = 'MSFT_xHostFileEntry'
+
+#region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Integration 
+#endregion
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+
+    InModuleScope $Global:DSCResourceName {
+
+        Describe $Global:DSCResourceName {
+            
+            Context "A host entry doesn't exist, and should" {
+                
+                Configuration xHostFileEntry_Add {
+                    node localhost {
+                        xHostFileEntry TestAdd {
+                            HostName = "www.contoso.com"
+                            IPAddress = "192.168.0.156"
+                        }
+                    }
+                }
+                
+                It "should compile a MOF file without error" {
+                    {
+                        xHostFileEntry_Add -OutputPath (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add")
+                    } | Should Not Throw
+                }
+                
+                It "should apply the MOF correctly" {
+                    {
+                        Start-DscConfiguration -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") -ComputerName localhost -Wait -Verbose -Force
+                    } | Should Not Throw
+                }
+                
+                It "should return a compliant state after being applied" {
+                    Test-DscConfiguration -ComputerName localhost -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") | Should Be $true
+                }
+                
+                It "should return Get-DscConfiguration without error" {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+                }
+            }
+        }
+    } #end InModuleScope $DSCResourceName
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -39,16 +39,12 @@ try
             
             It "should apply the MOF correctly" {
                 {
-                    Start-DscConfiguration -ComputerName "localhost" -Path $ConfigDir -Wait -Verbose -Force
+                    Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
                 } | Should Not Throw
             }
             
             It "should return a compliant state after being applied" {
-                (Test-DscConfiguration -ComputerName "localhost" -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
-            }
-            
-            It "should return Get-DscConfiguration without error" {
-                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+                (Test-DscConfiguration -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
             }
         }
         

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -28,25 +28,32 @@ try
         
         Context "A host entry doesn't exist, and should" {
             $CurrentConfig = "xHostFileEntry_Add"
+            $ConfigDir = (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
+            $ConfigMof = (Join-Path $ConfigDir "localhost.mof")
+            
             It "should compile a MOF file without error" {
                 {
-                    xHostFileEntry_Add -OutputPath (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
+                    xHostFileEntry_Add -OutputPath $ConfigDir
                 } | Should Not Throw
             }
             
             It "should apply the MOF correctly" {
                 {
-                    Start-DscConfiguration -Path (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig) -ComputerName localhost -Wait -Verbose -Force
+                    Start-DscConfiguration -Path $ConfigDir -ComputerName "localhost" -Wait -Verbose -Force
                 } | Should Not Throw
             }
             
             It "should return a compliant state after being applied" {
-                Test-DscConfiguration -ComputerName localhost -Path (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig) | Should Be $true
+                (Test-DscConfiguration -ComputerName "localhost" -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
             }
             
             It "should return Get-DscConfiguration without error" {
                 { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
             }
+        }
+        
+        AfterEach {
+            Remove-DscConfigurationDocument -Stage Current, Pending, Previous -Force -Confirm:$false
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -20,35 +20,28 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Begin Testing
 try
 {
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    . $ConfigFile
+    
     #region Pester Tests
-    Describe $Global:DSCResourceName {
+    Describe $"$($Global:DSCResourceName)_Integration" {
         
         Context "A host entry doesn't exist, and should" {
-            
-            Configuration xHostFileEntry_Add {
-                Import-DscResource -ModuleName xComputerManagement
-                node localhost {
-                    xHostFileEntry TestAdd {
-                        HostName = "www.contoso.com"
-                        IPAddress = "192.168.0.156"
-                    }
-                }
-            }
-            
+            $CurrentConfig = "xHostFileEntry_Add"
             It "should compile a MOF file without error" {
                 {
-                    xHostFileEntry_Add -OutputPath (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add")
+                    xHostFileEntry_Add -OutputPath (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
                 } | Should Not Throw
             }
             
             It "should apply the MOF correctly" {
                 {
-                    Start-DscConfiguration -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") -ComputerName localhost -Wait -Verbose -Force
+                    Start-DscConfiguration -Path (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig) -ComputerName localhost -Wait -Verbose -Force
                 } | Should Not Throw
             }
             
             It "should return a compliant state after being applied" {
-                Test-DscConfiguration -ComputerName localhost -Path (Join-Path $TestEnvironment.WorkingFolder "xHostFileEntry_Add") | Should Be $true
+                Test-DscConfiguration -ComputerName localhost -Path (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig) | Should Be $true
             }
             
             It "should return Get-DscConfiguration without error" {

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -39,12 +39,12 @@ try
             
             It "should apply the MOF correctly" {
                 {
-                    Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                    Start-DscConfiguration -ComputerName "localhost" -Path $ConfigDir -Wait -Verbose -Force
                 } | Should Not Throw
             }
             
             It "should return a compliant state after being applied" {
-                (Test-DscConfiguration -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
+                (Test-DscConfiguration -ComputerName "localhost" -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
             }
             
             It "should return Get-DscConfiguration without error" {

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -26,6 +26,7 @@ try
         Context "A host entry doesn't exist, and should" {
             
             Configuration xHostFileEntry_Add {
+                Import-DscResource -ModuleName xComputerManagement
                 node localhost {
                     xHostFileEntry TestAdd {
                         HostName = "www.contoso.com"

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-$Global:DSCModuleName      = 'xHostFileEntry'
+$Global:DSCModuleName      = 'xComputerManagement'
 $Global:DSCResourceName    = 'MSFT_xHostFileEntry'
 
 #region HEADER

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-$Global:DSCModuleName      = 'xComputerManagement'
+$Global:DSCModuleName      = 'xHostFileEntry'
 $Global:DSCResourceName    = 'MSFT_xHostFileEntry'
 
 #region HEADER

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -92,7 +92,7 @@ try
             }
         }
         
-        ontext "A host doesn't exist and it shouldn't" {
+        Context "A host doesn't exist and it shouldn't" {
             $CurrentConfig = "xHostFileEntry_AlreadyGone"
             $ConfigDir = (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
             $ConfigMof = (Join-Path $ConfigDir "localhost.mof")

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -92,6 +92,28 @@ try
             }
         }
         
+        ontext "A host doesn't exist and it shouldn't" {
+            $CurrentConfig = "xHostFileEntry_AlreadyGone"
+            $ConfigDir = (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
+            $ConfigMof = (Join-Path $ConfigDir "localhost.mof")
+            
+            It "should compile a MOF file without error" {
+                {
+                    .$CurrentConfig -OutputPath $ConfigDir
+                } | Should Not Throw
+            }
+            
+            It "should apply the MOF correctly" {
+                {
+                    Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+            
+            It "should return a compliant state after being applied" {
+                (Test-DscConfiguration -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
+            }
+        }
+        
         AfterEach {
             Remove-DscConfigurationDocument -Stage Current, Pending, Previous -Force -Confirm:$false -WarningAction SilentlyContinue
         }

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -39,12 +39,12 @@ try
             
             It "should apply the MOF correctly" {
                 {
-                    Start-DscConfiguration -Path $ConfigDir -ComputerName "localhost" -Wait -Verbose -Force
+                    Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
                 } | Should Not Throw
             }
             
             It "should return a compliant state after being applied" {
-                (Test-DscConfiguration -ComputerName "localhost" -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
+                (Test-DscConfiguration -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
             }
             
             It "should return Get-DscConfiguration without error" {
@@ -53,7 +53,7 @@ try
         }
         
         AfterEach {
-            Remove-DscConfigurationDocument -Stage Current, Pending, Previous -Force -Confirm:$false
+            Remove-DscConfigurationDocument -Stage Current, Pending, Previous -Force -Confirm:$false -WarningAction SilentlyContinue
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostFileEntry.Integration.Tests.ps1
@@ -33,7 +33,51 @@ try
             
             It "should compile a MOF file without error" {
                 {
-                    xHostFileEntry_Add -OutputPath $ConfigDir
+                    . $CurrentConfig -OutputPath $ConfigDir
+                } | Should Not Throw
+            }
+            
+            It "should apply the MOF correctly" {
+                {
+                    Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+            
+            It "should return a compliant state after being applied" {
+                (Test-DscConfiguration -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
+            }
+        }
+        
+        Context "A host entry exists, but has the wrong IP address" {
+            $CurrentConfig = "xHostFileEntry_Edit"
+            $ConfigDir = (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
+            $ConfigMof = (Join-Path $ConfigDir "localhost.mof")
+            
+            It "should compile a MOF file without error" {
+                {
+                    .$CurrentConfig -OutputPath $ConfigDir
+                } | Should Not Throw
+            }
+            
+            It "should apply the MOF correctly" {
+                {
+                    Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                } | Should Not Throw
+            }
+            
+            It "should return a compliant state after being applied" {
+                (Test-DscConfiguration -ReferenceConfiguration $ConfigMof).InDesiredState | Should be $true 
+            }
+        }
+        
+        Context "A host entry exists, but it shouldn't" {
+            $CurrentConfig = "xHostFileEntry_Remove"
+            $ConfigDir = (Join-Path $TestEnvironment.WorkingFolder $CurrentConfig)
+            $ConfigMof = (Join-Path $ConfigDir "localhost.mof")
+            
+            It "should compile a MOF file without error" {
+                {
+                    .$CurrentConfig -OutputPath $ConfigDir
                 } | Should Not Throw
             }
             

--- a/Tests/Unit/MSFT_xHostFileEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_xHostFileEntry.Tests.ps1
@@ -1,0 +1,173 @@
+﻿$Global:DSCModuleName      = 'xComputerManagement'
+$Global:DSCResourceName    = 'MSFT_xComputer'
+
+#region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit 
+#endregion
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+
+    InModuleScope $Global:DSCResourceName {
+
+        Describe $Global:DSCResourceName {
+            
+            Mock Add-Content {}
+            Mock Set-Content {}
+            
+            Context "A host entry doesn't exist, and should" {
+                $testParams = @{
+                    HostName = "www.contoso.com"
+                    IPAddress = "192.168.0.156"
+                }
+                
+                Mock Get-Content return @(
+                    "# A mocked example of a host file - this line is a comment",
+                    "",
+                    "127.0.0.1       localhost",
+                    "127.0.0.1  www.anotherexample.com",
+                    ""
+                )
+                
+                It "should return absent from the get method" {
+                    (Get-TargetResource @testParams).Ensure | Should Be "Absent" 
+                }
+                
+                It "should return false from the test method" {
+                    Test-TargetResource @testParams | Should Be $false
+                }
+                
+                It "should create the entry in the set method" {
+                    Set-TargetResource @testParams
+                    Assert-MockCalled Add-Content
+                }
+            }
+            
+            Context "A host entry exists but has the wrong IP address" {
+                $testParams = @{
+                    HostName = "www.contoso.com"
+                    IPAddress = "192.168.0.156"
+                }
+                
+                Mock Get-Content return @(
+                    "# A mocked example of a host file - this line is a comment",
+                    "",
+                    "127.0.0.1       localhost",
+                    "127.0.0.1  www.anotherexample.com",
+                    "127.0.0.1         $($testParams.HostName)",
+                    ""
+                )
+                
+                It "should return present from the get method" {
+                    (Get-TargetResource @testParams).Ensure | Should Be "Present" 
+                }
+                
+                It "should return false from the test method" {
+                    Test-TargetResource @testParams | Should Be $false
+                }
+                
+                It "should update the entry in the set method" {
+                    Set-TargetResource @testParams
+                    Assert-MockCalled Set-Content
+                }
+            }
+            
+            Context "A host entry exists with the correct IP address" {
+                $testParams = @{
+                    HostName = "www.contoso.com"
+                    IPAddress = "192.168.0.156"
+                }
+                
+                Mock Get-Content return @(
+                    "# A mocked example of a host file - this line is a comment",
+                    "",
+                    "127.0.0.1       localhost",
+                    "127.0.0.1  www.anotherexample.com",
+                    "$($testParams.IPAddress)         $($testParams.HostName)",
+                    ""
+                )
+                
+                It "should return present from the get method" {
+                    (Get-TargetResource @testParams).Ensure | Should Be "Present"
+                }
+                
+                It "should return true from the test method" {
+                    Test-TargetResource @testParams | Should Be $true
+                }
+            }
+            
+            Context "A host entry exists but it shouldn't" {
+                $testParams = @{
+                    HostName = "www.contoso.com"
+                    Ensure = "Absent"
+                }
+                
+                Mock Get-Content return @(
+                    "# A mocked example of a host file - this line is a comment",
+                    "",
+                    "127.0.0.1       localhost",
+                    "127.0.0.1  www.anotherexample.com",
+                    "127.0.0.1         $($testParams.HostName)",
+                    ""
+                )
+                
+                It "should return present from the get method" {
+                    (Get-TargetResource @testParams).Ensure | Should Be "Present"
+                }
+                
+                It "should return false from the test method" {
+                    Test-TargetResource @testParams | Should Be $false
+                }
+                
+                It "should remove the entry in the set method" {
+                    Set-TargetResource @testParams
+                    Assert-MockCalled Set-Content
+                }
+            }
+            
+            Context "A host entry doesn't it exist and shouldn't" {
+                $testParams = @{
+                    HostName = "www.contoso.com"
+                    Ensure = "Absent"
+                }
+                
+                Mock Get-Content return @(
+                    "# A mocked example of a host file - this line is a comment",
+                    "",
+                    "127.0.0.1       localhost",
+                    "127.0.0.1  www.anotherexample.com",
+                    ""
+                )
+                
+                It "should return absent from the get method" {
+                    (Get-TargetResource @testParams).Ensure | Should Be "Absent"
+                }
+                
+                It "should return true from the test method" {
+                    Test-TargetResource @testParams | Should Be $true
+                }
+            }
+        }
+    } #end InModuleScope $DSCResourceName
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Unit/MSFT_xHostFileEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_xHostFileEntry.Tests.ps1
@@ -35,13 +35,15 @@ try
                     IPAddress = "192.168.0.156"
                 }
                 
-                Mock Get-Content return @(
-                    "# A mocked example of a host file - this line is a comment",
-                    "",
-                    "127.0.0.1       localhost",
-                    "127.0.0.1  www.anotherexample.com",
-                    ""
-                )
+                Mock Get-Content { 
+                    return @(
+                        "# A mocked example of a host file - this line is a comment",
+                        "",
+                        "127.0.0.1       localhost",
+                        "127.0.0.1  www.anotherexample.com",
+                        ""
+                    )
+                }
                 
                 It "should return absent from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Absent" 
@@ -63,14 +65,16 @@ try
                     IPAddress = "192.168.0.156"
                 }
                 
-                Mock Get-Content return @(
-                    "# A mocked example of a host file - this line is a comment",
-                    "",
-                    "127.0.0.1       localhost",
-                    "127.0.0.1  www.anotherexample.com",
-                    "127.0.0.1         $($testParams.HostName)",
-                    ""
-                )
+                Mock Get-Content {
+                    return @(
+                        "# A mocked example of a host file - this line is a comment",
+                        "",
+                        "127.0.0.1       localhost",
+                        "127.0.0.1  www.anotherexample.com",
+                        "127.0.0.1         $($testParams.HostName)",
+                        ""
+                    )
+                }
                 
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present" 
@@ -92,14 +96,16 @@ try
                     IPAddress = "192.168.0.156"
                 }
                 
-                Mock Get-Content return @(
-                    "# A mocked example of a host file - this line is a comment",
-                    "",
-                    "127.0.0.1       localhost",
-                    "127.0.0.1  www.anotherexample.com",
-                    "$($testParams.IPAddress)         $($testParams.HostName)",
-                    ""
-                )
+                Mock Get-Content {
+                    return @(
+                        "# A mocked example of a host file - this line is a comment",
+                        "",
+                        "127.0.0.1       localhost",
+                        "127.0.0.1  www.anotherexample.com",
+                        "$($testParams.IPAddress)         $($testParams.HostName)",
+                        ""
+                    )
+                }
                 
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present"
@@ -116,14 +122,16 @@ try
                     Ensure = "Absent"
                 }
                 
-                Mock Get-Content return @(
-                    "# A mocked example of a host file - this line is a comment",
-                    "",
-                    "127.0.0.1       localhost",
-                    "127.0.0.1  www.anotherexample.com",
-                    "127.0.0.1         $($testParams.HostName)",
-                    ""
-                )
+                Mock Get-Content {
+                    return @(
+                        "# A mocked example of a host file - this line is a comment",
+                        "",
+                        "127.0.0.1       localhost",
+                        "127.0.0.1  www.anotherexample.com",
+                        "127.0.0.1         $($testParams.HostName)",
+                        ""
+                    )
+                }
                 
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present"
@@ -145,13 +153,15 @@ try
                     Ensure = "Absent"
                 }
                 
-                Mock Get-Content return @(
-                    "# A mocked example of a host file - this line is a comment",
-                    "",
-                    "127.0.0.1       localhost",
-                    "127.0.0.1  www.anotherexample.com",
-                    ""
-                )
+                Mock Get-Content {
+                    return @(
+                        "# A mocked example of a host file - this line is a comment",
+                        "",
+                        "127.0.0.1       localhost",
+                        "127.0.0.1  www.anotherexample.com",
+                        ""
+                    )
+                }
                 
                 It "should return absent from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Absent"

--- a/Tests/Unit/MSFT_xHostFileEntry.Tests.ps1
+++ b/Tests/Unit/MSFT_xHostFileEntry.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿$Global:DSCModuleName      = 'xComputerManagement'
-$Global:DSCResourceName    = 'MSFT_xComputer'
+$Global:DSCResourceName    = 'MSFT_xHostFileEntry'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@
 #      environment configuration  # 
 #---------------------------------# 
 version: 1.5.{build}.0
+image: WMF 5
 install: 
   - cinst -y pester
   - git clone https://github.com/PowerShell/DscResource.Tests


### PR DESCRIPTION
This is a new resource for managing host file entries on the local server (something we find ourselves doing a bit with SharePoint servers). Pretty straight forward resource in terms of properties and logic, just matching text in the host file.

I've included updates to the readme, examples, unit tests and added new integration tests for this component also.

Let me know if it needs anything else before it can be merged in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/31)
<!-- Reviewable:end -->
