### PR TITLE
By specifying the name as localhost the computer can be joined to a domain by its current name

### DIFF
--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -61,6 +61,11 @@ function Set-TargetResource
     )
 
     ValidateDomainOrWorkGroup -DomainName $DomainName -WorkGroupName $WorkGroupName
+    
+    if ($Name -eq 'localhost')
+    {
+        $Name = $env:COMPUTERNAME
+    }
 
     if ($Credential)
     {
@@ -215,11 +220,11 @@ function Test-TargetResource
 
         [string] $WorkGroupName
     )
-
+    
     Write-Verbose -Message "Validate desired Name is a valid name"
     
-    Write-Verbose -Message "Checking if computer name is $Name"
-    if ($Name -ne $env:COMPUTERNAME) {return $false}
+    Write-Verbose -Message "Checking if computer name is correct"
+    if (($Name -ne 'localhost') -and ($Name -ne $env:COMPUTERNAME)) {return $false}
 
     ValidateDomainOrWorkGroup -DomainName $DomainName -WorkGroupName $WorkGroupName
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ xScheduledTask has the following properties:
 ## Versions
 
 ### Unreleased
+* The Name parameter resolves to $env:COMPUTERNAME when the value is localhost
 
 ### 1.6.0.0
 * Added the following resources:


### PR DESCRIPTION
This addresses issue 29.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/37)
<!-- Reviewable:end -->
