### PR TITLE
DomainName check validates child without FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ xVirtualMemory has the following properties:
 ## Versions
 
 ### Unreleased
+* xComputer: Changed comparision that validates if we are in the correct AD Domain to work correctly if FQDN wasn't used
 
 ### 1.10.0.0
 * Added resources


### PR DESCRIPTION
The condition for verifying we're in the correct domain throws a non-terminating error if a child domain was used as input without FQDN. All other functions worked correctly in that scenario except validating the computer is in the correct domain. This change allows lacking FQDN to still return true value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/76)
<!-- Reviewable:end -->
