### PR TITLE
Fix BOM, Optin to Common Tests, Fix License Year, Add VSCode Styles - Fixes 87

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -1,4 +1,6 @@
 [
         "Common Tests - Validate Markdown Files",
-        "Common Tests - Validate Example Files"
+        "Common Tests - Validate Example Files",
+        "Common Tests - Validate Module Files",
+        "Common Tests - Validate Script Files"
 ]

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+If you'd like to contribute to this project, please review the [Contribution Guidelines](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--
+Your feedback and support is greatly appreciated, thanks for contributing!
+
+Please prefix the issue title with the resource name, i.e. 'xCertReq: Short description of my issue'
+Please provide the following information regarding your issue (place N/A if the fields that don't apply to your issue):
+-->
+**Details of the scenario you tried and the problem that is occurring:**
+
+**The DSC configuration that is using the resource (as detailed as possible):**
+
+**Version of the Operating System and PowerShell the DSC Target Node is running:**
+
+**Version of the DSC module you're using, or 'dev' if you're using current dev branch:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Your feedback and support is greatly appreciated, thanks for contributing!
 
-Please prefix the issue title with the resource name, i.e. 'xCertReq: Short description of my issue'
+Please prefix the issue title with the resource name, i.e. 'xComputer: Short description of my issue'
 Please provide the following information regarding your issue (place N/A if the fields that don't apply to your issue):
 -->
 **Details of the scenario you tried and the problem that is occurring:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!
+
+Please prefix the PR title with the resource name, i.e. 'xCertReq: My short description'
+If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xCertReq: My short description'
+
+To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
+Change to [x] for each task in the task list that applies to this PR.
+-->
+**Pull Request (PR) description**
+<!-- Replace this with a description of your pull request -->
+
+**This Pull Request (PR) fixes the following issues:**
+<!-- Replace this with the list of issues or n/a. Use format: Fixes #123 -->
+
+**Task list:**
+- [ ] Change details added to Unreleased section of CHANGELOG.md?
+- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
+- [ ] Examples appropriately updated?
+- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
+- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
 Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!
 
-Please prefix the PR title with the resource name, i.e. 'xCertReq: My short description'
-If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xCertReq: My short description'
+Please prefix the PR title with the resource name, i.e. 'xComputer: My short description'
+If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xComputer: My short description'
 
 To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
 Change to [x] for each task in the task list that applies to this PR.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "powershell.codeFormatting.openBraceOnSameLine": false,
+    "powershell.codeFormatting.newLineAfterOpenBrace": false,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.preset": "Custom",
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true
+}

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -1,4 +1,4 @@
-﻿<#
+<#
     .SYNOPSIS
         Retrieves the localized string data based on the machine's culture.
         Falls back to en-US strings if the machine's culture is not supported.
@@ -87,17 +87,17 @@ function Test-DscParameterState
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $CurrentValues,
 
-        [Parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true)]
         [object]
         $DesiredValues,
-        
+
         [string[]]
         $ValuesToCheck,
-        
+
         [switch]
         $TurnOffTypeChecking
     )
@@ -105,7 +105,7 @@ function Test-DscParameterState
     $returnValue = $true
 
     $types = 'System.Management.Automation.PSBoundParametersDictionary', 'System.Collections.Hashtable', 'Microsoft.Management.Infrastructure.CimInstance'
-    
+
     if ($DesiredValues.GetType().FullName -notin $types)
     {
         throw ("Property 'DesiredValues' in Test-DscParameterState must be either a Hashtable or CimInstance. Type detected was $($DesiredValues.GetType().FullName)")
@@ -115,13 +115,13 @@ function Test-DscParameterState
     {
         throw ("If 'DesiredValues' is a CimInstance then property 'ValuesToCheck' must contain a value")
     }
-    
+
     $desiredValuesClean = Remove-CommonParameter -Hashtable $DesiredValues
 
     if (-not $ValuesToCheck)
     {
         $keyList = $desiredValuesClean.Keys
-    } 
+    }
     else
     {
         $keyList = $ValuesToCheck
@@ -135,19 +135,19 @@ function Test-DscParameterState
         }
         else
         {
-            $desiredType = [psobject]@{ 
-                Name = 'Unknown' 
+            $desiredType = [psobject]@{
+                Name = 'Unknown'
             }
         }
-        
+
         if ($null -ne $CurrentValues.$key)
         {
             $currentType = $CurrentValues.$key.GetType()
         }
         else
         {
-            $currentType = [psobject]@{ 
-                Name = 'Unknown' 
+            $currentType = [psobject]@{
+                Name = 'Unknown'
             }
         }
 
@@ -164,7 +164,7 @@ function Test-DscParameterState
                 Write-Verbose -Message ('NOTMATCH: PSCredential username mismatch. Current state is {0} and desired state is {1}' -f $CurrentValues.$key.UserName, $desiredValuesClean.$key.UserName)
                 $returnValue = $false
             }
-            
+
             # Assume the string is our username when the matching desired value is actually a credential
             if ($currentType.Name -eq 'string' -and $CurrentValues.$key -eq $desiredValuesClean.$key.UserName)
             {
@@ -177,10 +177,10 @@ function Test-DscParameterState
                 $returnValue = $false
             }
         }
-     
+
         if (-not $TurnOffTypeChecking)
-        {   
-            if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and 
+        {
+            if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and
                 $desiredType.FullName -ne $currentType.FullName)
             {
                 Write-Verbose -Message "NOTMATCH: Type mismatch for property '$key' Current state type is '$($currentType.Name)' and desired type is '$($desiredType.Name)'"
@@ -193,22 +193,22 @@ function Test-DscParameterState
             Write-Verbose -Message "MATCH: Value (type $($desiredType.Name)) for property '$key' does match. Current state is '$($CurrentValues.$key)' and desired state is '$($desiredValuesClean.$key)'"
             continue
         }
-                    
+
         if ($desiredValuesClean.GetType().Name -in 'HashTable', 'PSBoundParametersDictionary')
         {
             $checkDesiredValue = $desiredValuesClean.ContainsKey($key)
-        } 
+        }
         else
         {
             $checkDesiredValue = Test-DSCObjectHasProperty -Object $desiredValuesClean -PropertyName $key
         }
-        
+
         if (-not $checkDesiredValue)
         {
             Write-Verbose -Message "MATCH: Value (type $($desiredType.Name)) for property '$key' does match. Current state is '$($CurrentValues.$key)' and desired state is '$($desiredValuesClean.$key)'"
             continue
         }
-        
+
         if ($desiredType.IsArray)
         {
             Write-Verbose -Message "Comparing values in property '$key'"
@@ -237,11 +237,11 @@ function Test-DscParameterState
                     }
                     else
                     {
-                        $desiredType = [psobject]@{ 
+                        $desiredType = [psobject]@{
                             Name = 'Unknown'
                         }
                     }
-                    
+
                     if ($null -ne $currentArrayValues[$i])
                     {
                         $currentType = $currentArrayValues[$i].GetType()
@@ -249,13 +249,13 @@ function Test-DscParameterState
                     else
                     {
                         $currentType = [psobject]@{
-                            Name = 'Unknown' 
+                            Name = 'Unknown'
                         }
                     }
-                    
+
                     if (-not $TurnOffTypeChecking)
                     {
-                        if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and 
+                        if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and
                             $desiredType.FullName -ne $currentType.FullName)
                         {
                             Write-Verbose -Message "`tNOTMATCH: Type mismatch for property '$key' Current state type of element [$i] is '$($currentType.Name)' and desired type is '$($desiredType.Name)'"
@@ -263,7 +263,7 @@ function Test-DscParameterState
                             continue
                         }
                     }
-                        
+
                     if ($desiredArrayValues[$i] -ne $currentArrayValues[$i])
                     {
                         Write-Verbose -Message "`tNOTMATCH: Value [$i] (type $($desiredType.Name)) for property '$key' does match. Current state is '$($currentArrayValues[$i])' and desired state is '$($desiredArrayValues[$i])'"
@@ -276,20 +276,20 @@ function Test-DscParameterState
                         continue
                     }
                 }
-                
+
             }
-        } 
-        else 
+        }
+        else
         {
             if ($desiredValuesClean.$key -ne $CurrentValues.$key)
             {
                 Write-Verbose -Message "NOTMATCH: Value (type $($desiredType.Name)) for property '$key' does not match. Current state is '$($CurrentValues.$key)' and desired state is '$($desiredValuesClean.$key)'"
                 $returnValue = $false
             }
-        
-        } 
+
+        }
     }
-    
+
     Write-Verbose -Message "Result is '$returnValue'"
     return $returnValue
 }
@@ -308,7 +308,7 @@ function Test-DSCObjectHasProperty
     [OutputType([bool])]
     param
     (
-        [Parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true)]
         [object]
         $Object,
 
@@ -317,11 +317,11 @@ function Test-DSCObjectHasProperty
         $PropertyName
     )
 
-    if ($Object.PSObject.Properties.Name -contains $PropertyName) 
+    if ($Object.PSObject.Properties.Name -contains $PropertyName)
     {
         return [bool] $Object.$PropertyName
     }
-    
+
     return $false
 }
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Microsoft Corporation.
+Copyright (c) 2017 Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ xVirtualMemory has the following properties:
 * Change examples to meet HQRM standards and optin to Example validation
   tests.
 * Replaced examples in README.MD to links to Example files.
+* Added the VS Code PowerShell extension formatting settings that cause PowerShell.
+  files to be formatted as per the DSC Resource kit style guidelines - [Issue #91](https://github.com/PowerShell/xComputerManagement/issues/91).
+* Opted into Common Tests 'Validate Module Files' and 'Validate Script Files'.
+* Converted files with UTF8 with BOM over to UTF8 - fixes [Issue #90](https://github.com/PowerShell/xComputerManagement/issues/90).
+* Updated Year to 2017 in License and Manifest - fixes [Issue #87](https://github.com/PowerShell/xComputerManagement/issues/87).
+* Added .github support files - fixes [Issue #88](https://github.com/PowerShell/xComputerManagement/issues/88):
+  * CONTRIBUTING.md
+  * ISSUE_TEMPLATE.md
+  * PULL_REQUEST_TEMPLATE.md
 
 ### 2.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ xVirtualMemory has the following properties:
 * Change examples to meet HQRM standards and optin to Example validation
   tests.
 * Replaced examples in README.MD to links to Example files.
-* Added the VS Code PowerShell extension formatting settings that cause PowerShell.
+* Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines - [Issue #91](https://github.com/PowerShell/xComputerManagement/issues/91).
 * Opted into Common Tests 'Validate Module Files' and 'Validate Script Files'.
 * Converted files with UTF8 with BOM over to UTF8 - fixes [Issue #90](https://github.com/PowerShell/xComputerManagement/issues/90).

--- a/Tests/Unit/MSFT_xComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xComputer.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$Global:DSCModuleName      = 'xComputerManagement'
+$Global:DSCModuleName      = 'xComputerManagement'
 $Global:DSCResourceName    = 'MSFT_xComputer'
 
 #region HEADER
@@ -16,7 +16,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 #endregion
 
 # Begin Testing
@@ -31,7 +31,7 @@ try
             $SecPassword = New-Object -Type SecureString
             $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'USER',$SecPassword
             $NotComputerName  = if($env:COMPUTERNAME -ne 'othername'){'othername'}else{'name'}
-        
+
             Context "$($Global:DSCResourceName)\Test-TargetResource" {
                 Mock Get-WMIObject {[PSCustomObject]@{DomainName = 'ContosoLtd'}} -ParameterFilter {$Class -eq 'Win32_NTDomain'}
                 It 'Throws if both DomainName and WorkGroupName are specified' {
@@ -121,7 +121,7 @@ try
                 It 'Should not Throw if name is localhost' {
                     {Test-TargetResource -Name "localhost"} | Should Not Throw
                 }
-                
+
             }
             Context "$($Global:DSCResourceName)\Get-TargetResource" {
                 It 'should not throw' {

--- a/xComputerManagement.psd1
+++ b/xComputerManagement.psd1
@@ -12,7 +12,7 @@ Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'
 
 # Copyright statement for this module
-Copyright = '(c) 2014 Microsoft Corporation. All rights reserved.'
+Copyright = '(c) 2017 Microsoft Corporation. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'The xComputerManagement module is originally part of the Windows PowerShell Desired State Configuration (DSC) Resource Kit. This version has been modified for use in Azure. This module contains the xComputer and xDisk resources. These DSC Resources allow you to perform computer management tasks, like joining a domain or initializing disks.


### PR DESCRIPTION
**Pull Request (PR) description**
Several of the module files were using UTF8 with BOM encoding. This PR converts them to UTF8 encoding. It also opts into the common tests:
"Common Tests - Validate Module Files"
"Common Tests - Validate Script Files"

The copyright year has also been updated to 2017 in the License.md and the module manifest.

The standard GitHub templates were added and the standard VSCode style settings were included as well.

**This Pull Request (PR) fixes the following issues:**
Fixes #87 
Fixes #88 
Fixes #90
Fixes #91 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/92)
<!-- Reviewable:end -->
