### PR TITLE
xVirtualMemory: Refactor and improve unit test coverage and HQRM - Fixes #95

### DIFF
--- a/DSCResources/MSFT_xVirtualMemory/MSFT_xVirtualMemory.psm1
+++ b/DSCResources/MSFT_xVirtualMemory/MSFT_xVirtualMemory.psm1
@@ -42,7 +42,7 @@ function Get-TargetResource
         MaximumSize = 0
     }
 
-    [bool] $isSystemManaged = (Get-CimInstance -ClassName 'Win32_ComputerSystem').AutomaticManagedPagefile
+    [System.Boolean] $isSystemManaged = (Get-CimInstance -ClassName 'Win32_ComputerSystem').AutomaticManagedPagefile
 
     if ($isSystemManaged)
     {
@@ -58,21 +58,22 @@ function Get-TargetResource
     if (-not $existingPageFileSetting)
     {
         $returnValue.Type = 'NoPagingFile'
-        return $returnValue
-    }
-
-    if ($existingPageFileSetting.InitialSize -eq 0 -and $existingPageFileSetting.MaximumSize -eq 0)
-    {
-        $returnValue.Type = 'SystemManagedSize'
     }
     else
     {
-        $returnValue.Type = 'CustomSize'
-    }
+        if ($existingPageFileSetting.InitialSize -eq 0 -and $existingPageFileSetting.MaximumSize -eq 0)
+        {
+            $returnValue.Type = 'SystemManagedSize'
+        }
+        else
+        {
+            $returnValue.Type = 'CustomSize'
+        }
 
-    $returnValue.Drive = $existingPageFileSetting.Name.Substring(0, 3)
-    $returnValue.InitialSize = $existingPageFileSetting.InitialSize
-    $returnValue.MaximumSize = $existingPageFileSetting.MaximumSize
+        $returnValue.Drive = $existingPageFileSetting.Name.Substring(0, 3)
+        $returnValue.InitialSize = $existingPageFileSetting.InitialSize
+        $returnValue.MaximumSize = $existingPageFileSetting.MaximumSize
+    }
 
     return $returnValue
 }
@@ -382,6 +383,20 @@ function Get-PageFileSetting
         -Filter "SettingID='pagefile.sys @ $Drive'"
 }
 
+<#
+    .SYNOPSIS
+        Sets a new page file name.
+
+    .PARAMETER Drive
+        The letter of the drive containing the page file
+        to change the settings of.
+
+    .PARAMETER InitialSize
+        The initial size to set the page file to.
+
+    .PARAMETER MaximumSize
+        The maximum size to set the page file to.
+#>
 function Set-PageFileSetting
 {
     [CmdletBinding()]

--- a/DSCResources/MSFT_xVirtualMemory/MSFT_xVirtualMemory.psm1
+++ b/DSCResources/MSFT_xVirtualMemory/MSFT_xVirtualMemory.psm1
@@ -139,13 +139,7 @@ function Set-TargetResource
                 Set-AutoManagePaging -State Disable
             }
 
-            $driveInfo = [System.IO.DriveInfo] $Drive
-
-            if (-not $driveInfo.IsReady)
-            {
-                New-InvalidOperationException `
-                    -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
-            }
+            $driveInfo = Get-DriveInfo -Drive $Drive
 
             $existingPageFileSetting = Get-PageFileSetting `
                 -Drive $($driveInfo.Name.Substring(0,2))
@@ -179,13 +173,7 @@ function Set-TargetResource
                 Set-AutoManagePaging -State Disable
             }
 
-            $driveInfo = [System.IO.DriveInfo] $Drive
-
-            if (-not $driveInfo.IsReady)
-            {
-                New-InvalidOperationException `
-                    -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
-            }
+            $driveInfo = Get-DriveInfo -Drive $Drive
 
             $existingPageFileSetting = Get-PageFileSetting `
                 -Drive $($driveInfo.Name.Substring(0,2))
@@ -217,13 +205,7 @@ function Set-TargetResource
                 Set-AutoManagePaging -State Disable
             }
 
-            $driveInfo = [System.IO.DriveInfo] $Drive
-
-            if (-not $driveInfo.IsReady)
-            {
-                New-InvalidOperationException `
-                    -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
-            }
+            $driveInfo = Get-DriveInfo -Drive $Drive
 
             $existingPageFileSetting = Get-PageFileSetting `
                 -Drive $($driveInfo.Name.Substring(0,2))
@@ -489,6 +471,38 @@ function New-PageFile
         -Property @{
             Name = $PageFileName
         }
+}
+
+<#
+    .SYNOPSIS
+        Gets the Drive info object for a specified
+        Drive. It will throw an exception if the drive
+        is invalid or does not exist.
+
+    .PARAMETER Drive
+        The letter of the drive to get the drive info
+        for.
+#>
+function Get-DriveInfo
+{
+    [CmdletBinding()]
+    [OutputType([System.IO.DriveInfo])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Drive
+    )
+
+    $driveInfo = [System.IO.DriveInfo] $Drive
+
+    if (-not $driveInfo.IsReady)
+    {
+        New-InvalidOperationException `
+            -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
+    }
+
+    return $driveInfo
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xVirtualMemory/MSFT_xVirtualMemory.psm1
+++ b/DSCResources/MSFT_xVirtualMemory/MSFT_xVirtualMemory.psm1
@@ -144,7 +144,7 @@ function Set-TargetResource
             if (-not $driveInfo.IsReady)
             {
                 New-InvalidOperationException `
-                    -Message ($script:localizedData.DisableAutoManagePaging -f $driveInfo.Name)
+                    -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
             }
 
             $existingPageFileSetting = Get-PageFileSetting `
@@ -184,7 +184,7 @@ function Set-TargetResource
             if (-not $driveInfo.IsReady)
             {
                 New-InvalidOperationException `
-                    -Message ($script:localizedData.DisableAutoManagePaging -f $driveInfo.Name)
+                    -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
             }
 
             $existingPageFileSetting = Get-PageFileSetting `
@@ -222,7 +222,7 @@ function Set-TargetResource
             if (-not $driveInfo.IsReady)
             {
                 New-InvalidOperationException `
-                    -Message ($script:localizedData.DisableAutoManagePaging -f $driveInfo.Name)
+                    -Message ($script:localizedData.DriveNotReadyError -f $driveInfo.Name)
             }
 
             $existingPageFileSetting = Get-PageFileSetting `

--- a/DSCResources/MSFT_xVirtualMemory/en-US/MSFT_xVirtualMemory.strings.psd1
+++ b/DSCResources/MSFT_xVirtualMemory/en-US/MSFT_xVirtualMemory.strings.psd1
@@ -1,0 +1,14 @@
+ConvertFrom-StringData @'
+    GettingVirtualMemoryMessage = Getting Virtual Memory.
+    SettingVirtualMemoryMessage = Setting Virtual Memory.
+    SetAutoManagePagingMessage = {0} automatically managed page file.
+    GettingPageFileSettingsMessage = Getting page file settings for drive {0}.
+    SettingPageFileSettingsMessage = Setting page file settings for drive {0} with initial size of {1}MB and maximum size {2}MB.
+    NewPageFileMessage = Specifting new page file '{0}'.
+    RemovePageFileMessage = Removing existing page file '{0}'.
+    DisabledPageFileMessage = Disabled page file for drive {0}.
+    EnabledSystemManagedSizeMessage = Enabled system managed page file for drive {0}.
+    EnabledCustomSizeMessage = Enabled custom size page file for drive {0}.
+    DriveNotReadyError = Drive {0} is not ready. Please ensure that the drive exists and is available.
+    TestingVirtualMemoryMessage = Testing Virtual Memory.
+'@

--- a/DSCResources/MSFT_xVirtualMemory/en-US/MSFT_xVirtualMemory.strings.psd1
+++ b/DSCResources/MSFT_xVirtualMemory/en-US/MSFT_xVirtualMemory.strings.psd1
@@ -4,7 +4,7 @@ ConvertFrom-StringData @'
     SetAutoManagePagingMessage = {0} automatically managed page file.
     GettingPageFileSettingsMessage = Getting page file settings for drive {0}.
     SettingPageFileSettingsMessage = Setting page file settings for drive {0} with initial size of {1}MB and maximum size {2}MB.
-    NewPageFileMessage = Specifting new page file '{0}'.
+    NewPageFileMessage = Creating new page file '{0}'.
     RemovePageFileMessage = Removing existing page file '{0}'.
     DisabledPageFileMessage = Disabled page file for drive {0}.
     EnabledSystemManagedSizeMessage = Enabled system managed page file for drive {0}.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ xVirtualMemory has the following properties:
 * xVirtualMemory:
   * Suppress PSScriptAnalyzer rule PSAvoidGlobalVars for
     `$global:DSCMachineStatus = 1`.
+  * Refactored shared common code into new utility functions to
+    reduce code duplication and improve testability.
+  * Moved strings into localizable strings file.
+  * Converted calls to `throw` to use `New-InvalidOperationException`
+    in CommonResourceHelper.
+  * Improved unit test coverage.
+  * Updated to meet HQRM guidelines.
 
 ### 2.0.0.0
 

--- a/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
@@ -125,8 +125,7 @@ try {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter $parameterFilterComputerSystem `
-                    -MockWith $mockAutomaticPagefileEnabled `
-                    -Verifiable
+                    -MockWith $mockAutomaticPagefileEnabled
 
                 It 'Should return type set to AutoManagePagingFile' {
                     $result = Get-TargetResource @testParameters
@@ -134,8 +133,6 @@ try {
                 }
 
                 It 'Should call the correct mocks' {
-                    Assert-VerifiableMocks
-
                     Assert-MockCalled `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
@@ -147,13 +144,11 @@ try {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter $parameterFilterComputerSystem `
-                    -MockWith $mockAutomaticPagefileDisabled `
-                    -Verifiable
+                    -MockWith $mockAutomaticPagefileDisabled
 
                 Mock `
                     -CommandName Get-PageFileSetting `
-                    -ParameterFilter $parameterFilterGetPageFileSetting `
-                    -Verifiable
+                    -ParameterFilter $parameterFilterGetPageFileSetting
 
                 It 'Should return type set to NoPagingFile' {
                     $result = Get-TargetResource @testParameters
@@ -161,8 +156,6 @@ try {
                 }
 
                 It 'Should call the correct mocks' {
-                    Assert-VerifiableMocks
-
                     Assert-MockCalled `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
@@ -179,8 +172,7 @@ try {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter $parameterFilterComputerSystem `
-                    -MockWith $mockAutomaticPagefileDisabled `
-                    -Verifiable
+                    -MockWith $mockAutomaticPagefileDisabled
 
                 Mock `
                     -CommandName Get-PageFileSetting `
@@ -191,18 +183,15 @@ try {
                             MaximumSize = 0
                             Name        = "$testDrive\"
                         }
-                    } `
-                    -Verifiable
+                    }
 
-                It 'Should not return a valid type and drive letter' {
+                It 'Should return a expected type and drive letter' {
                     $result = Get-TargetResource @testParameters
                     $result.Type | Should Be 'SystemManagedSize'
                     $result.Drive | Should Be ([System.IO.DriveInfo] $testParameters.Drive).Name
                 }
 
                 It 'Should call the correct mocks' {
-                    Assert-VerifiableMocks
-
                     Assert-MockCalled `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
@@ -219,8 +208,7 @@ try {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter $parameterFilterComputerSystem `
-                    -MockWith $mockAutomaticPagefileDisabled `
-                    -Verifiable
+                    -MockWith $mockAutomaticPagefileDisabled
 
                 Mock `
                     -CommandName Get-PageFileSetting `
@@ -231,18 +219,15 @@ try {
                             MaximumSize = 20
                             Name        = "$testDrive\"
                         }
-                    } `
-                    -Verifiable
+                    }
 
-                It 'Should not return a valid type and drive letter' {
+                It 'Should return expected type and drive letter' {
                     $result = Get-TargetResource @testParameters
                     $result.Type | Should Be 'CustomSize'
                     $result.Drive | Should Be ([System.IO.DriveInfo] $testParameters.Drive).Name
                 }
 
                 It 'Should call the correct mocks' {
-                    Assert-VerifiableMocks
-
                     Assert-MockCalled `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
@@ -281,15 +266,13 @@ try {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter $parameterFilterComputerSystem `
-                    -MockWith $mockAutomaticPagefileDisabled `
-                    -Verifiable
+                    -MockWith $mockAutomaticPagefileDisabled
 
                 Mock `
                     -CommandName Set-AutoManagePaging `
-                    -ParameterFilter { $State -eq 'Enable' } `
-                    -Verifiable
+                    -ParameterFilter { $State -eq 'Enable' }
 
-                It 'Should not throw exception' {
+                It 'Should not throw an exception' {
                     $testParameters = @{
                         Drive       = $testDrive
                         Type        = 'AutoManagePagingFile'
@@ -302,8 +285,6 @@ try {
                 }
 
                 It 'Should call the correct mocks' {
-                    Assert-VerifiableMocks
-
                     Assert-MockCalled `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
@@ -321,23 +302,19 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileEnabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileEnabled
 
                     Mock `
                         -CommandName Set-AutoManagePaging `
-                        -ParameterFilter { $State -eq 'Disable' } `
-                        -Verifiable
+                        -ParameterFilter { $State -eq 'Disable' }
 
                     Mock `
                         -CommandName Get-PageFileSetting `
-                        -ParameterFilter { $Drive -eq $testDrive } `
-                        -Verifiable
+                        -ParameterFilter { $Drive -eq $testDrive }
 
                     Mock `
                         -CommandName New-PageFile `
-                        -ParameterFilter { $PageFileName -eq $testPageFileName } `
-                        -Verifiable
+                        -ParameterFilter { $PageFileName -eq $testPageFileName }
 
                     Mock `
                         -CommandName Set-PageFileSetting `
@@ -345,10 +322,9 @@ try {
                             $Drive -eq $testDrive -and `
                             $InitialSize -eq $testInitialSize -and `
                             $MaximumSize -eq $testMaximumSize
-                        } `
-                        -Verifiable
+                        }
 
-                    It 'Should return false' {
+                    It 'Should not throw an exception' {
                         $testParameters = @{
                             Drive       = $testDrive
                             Type        = 'CustomSize'
@@ -361,8 +337,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -398,19 +372,16 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileEnabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileEnabled
 
                     Mock `
                         -CommandName Set-AutoManagePaging `
-                        -ParameterFilter { $State -eq 'Disable' } `
-                        -Verifiable
+                        -ParameterFilter { $State -eq 'Disable' }
 
                     Mock `
                         -CommandName Get-PageFileSetting `
                         -ParameterFilter { $Drive -eq $testDrive } `
-                        -MockWith $mockPageFileSetting `
-                        -Verifiable
+                        -MockWith $mockPageFileSetting
 
                     Mock `
                         -CommandName New-PageFile `
@@ -422,10 +393,9 @@ try {
                             $Drive -eq $testDrive -and `
                             $InitialSize -eq $testInitialSize -and `
                             $MaximumSize -eq $testMaximumSize
-                        } `
-                        -Verifiable
+                        }
 
-                    It 'Should return false' {
+                    It 'Should not throw an exception' {
                         $testParameters = @{
                             Drive       = $testDrive
                             Type        = 'CustomSize'
@@ -438,8 +408,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -476,32 +444,27 @@ try {
                         Mock `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
-                            -MockWith $mockAutomaticPagefileEnabled `
-                            -Verifiable
+                            -MockWith $mockAutomaticPagefileEnabled
 
                         Mock `
                             -CommandName Set-AutoManagePaging `
-                            -ParameterFilter { $State -eq 'Disable' } `
-                            -Verifiable
+                            -ParameterFilter { $State -eq 'Disable' }
 
                         Mock `
                             -CommandName Get-PageFileSetting `
-                            -ParameterFilter { $Drive -eq $testDrive } `
-                            -Verifiable
+                            -ParameterFilter { $Drive -eq $testDrive }
 
                         Mock `
                             -CommandName New-PageFile `
-                            -ParameterFilter { $PageFileName -eq $testPageFileName } `
-                            -Verifiable
+                            -ParameterFilter { $PageFileName -eq $testPageFileName }
 
                         Mock `
                             -CommandName Set-PageFileSetting `
                             -ParameterFilter {
                                 $Drive -eq $testDrive
-                            } `
-                            -Verifiable
+                            }
 
-                        It 'Should return false' {
+                        It 'Should not throw an exception' {
                             $testParameters = @{
                                 Drive       = $testDrive
                                 Type        = 'SystemManagedSize'
@@ -512,8 +475,6 @@ try {
                         }
 
                         It 'Should call the correct mocks' {
-                            Assert-VerifiableMocks
-
                             Assert-MockCalled `
                                 -CommandName Get-CimInstance `
                                 -ParameterFilter $parameterFilterComputerSystem `
@@ -548,19 +509,16 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileEnabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileEnabled
 
                     Mock `
                         -CommandName Set-AutoManagePaging `
-                        -ParameterFilter { $State -eq 'Disable' } `
-                        -Verifiable
+                        -ParameterFilter { $State -eq 'Disable' }
 
                     Mock `
                         -CommandName Get-PageFileSetting `
                         -ParameterFilter { $Drive -eq $testDrive } `
-                        -MockWith $mockPageFileSetting `
-                        -Verifiable
+                        -MockWith $mockPageFileSetting
 
                     Mock `
                         -CommandName New-PageFile `
@@ -570,10 +528,9 @@ try {
                         -CommandName Set-PageFileSetting `
                         -ParameterFilter {
                             $Drive -eq $testDrive
-                        } `
-                        -Verifiable
+                        }
 
-                    It 'Should return false' {
+                    It 'Should not throw an exception' {
                         $testParameters = @{
                             Drive       = $testDrive
                             Type        = 'SystemManagedSize'
@@ -584,8 +541,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -620,23 +575,20 @@ try {
                         Mock `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
-                            -MockWith $mockAutomaticPagefileEnabled `
-                            -Verifiable
+                            -MockWith $mockAutomaticPagefileEnabled
 
                         Mock `
                             -CommandName Set-AutoManagePaging `
-                            -ParameterFilter { $State -eq 'Disable' } `
-                            -Verifiable
+                            -ParameterFilter { $State -eq 'Disable' }
 
                         Mock `
                             -CommandName Get-PageFileSetting `
-                            -ParameterFilter { $Drive -eq $testDrive } `
-                            -Verifiable
+                            -ParameterFilter { $Drive -eq $testDrive }
 
                         Mock `
                             -CommandName Remove-CimInstance
 
-                        It 'Should return false' {
+                        It 'Should not throw an exception' {
                             $testParameters = @{
                                 Drive       = $testDrive
                                 Type        = 'NoPagingFile'
@@ -647,8 +599,6 @@ try {
                         }
 
                         It 'Should call the correct mocks' {
-                            Assert-VerifiableMocks
-
                             Assert-MockCalled `
                                 -CommandName Get-CimInstance `
                                 -ParameterFilter $parameterFilterComputerSystem `
@@ -675,25 +625,21 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileEnabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileEnabled
 
                     Mock `
                         -CommandName Set-AutoManagePaging `
-                        -ParameterFilter { $State -eq 'Disable' } `
-                        -Verifiable
+                        -ParameterFilter { $State -eq 'Disable' }
 
                     Mock `
                         -CommandName Get-PageFileSetting `
                         -ParameterFilter { $Drive -eq $testDrive } `
-                        -MockWith $mockPageFileSetting `
-                        -Verifiable
+                        -MockWith $mockPageFileSetting
 
                     Mock `
-                        -CommandName Remove-CimInstance `
-                        -Verifiable
+                        -CommandName Remove-CimInstance
 
-                    It 'Should return false' {
+                    It 'Should not throw an exception' {
                         $testParameters = @{
                             Drive       = $testDrive
                             Type        = 'NoPagingFile'
@@ -704,8 +650,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -731,12 +675,11 @@ try {
 
         Describe 'MSFT_xVirtualMemory\Test-TargetResource' {
             Context 'In desired state' {
-                Context 'With automatic managed page file is enabled' {
+                Context 'When automatic managed page file is enabled' {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileEnabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileEnabled
 
                     It 'Should return true' {
                         $testParameters = @{
@@ -752,8 +695,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -761,17 +702,15 @@ try {
                     }
                 }
 
-                Context 'With automatic managed page file is disabled and no page file set' {
+                Context 'When automatic managed page file is disabled and no page file set' {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
-                        -ParameterFilter $parameterFilterGetPageFileSetting `
-                        -Verifiable
+                        -ParameterFilter $parameterFilterGetPageFileSetting
 
                     It 'Should return true' {
                         $testParameters = @{
@@ -787,8 +726,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -805,8 +742,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
@@ -817,8 +753,7 @@ try {
                                 MaximumSize = 0
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
                     It 'Should return true' {
                         $testParameters = @{
@@ -834,8 +769,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -852,8 +785,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
@@ -864,8 +796,7 @@ try {
                                 MaximumSize = $testMaximumSize
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
                     It 'Should return true' {
                         $testParameters = @{
@@ -881,8 +812,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -901,8 +830,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     It 'Should return false' {
                         $testParameters = @{
@@ -918,8 +846,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -931,8 +857,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
@@ -943,8 +868,7 @@ try {
                                 MaximumSize = $testMaximumSize
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
                     It 'Should return false' {
                         $testParameters = @{
@@ -960,8 +884,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -978,8 +900,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
@@ -990,8 +911,7 @@ try {
                                 MaximumSize = $testMaximumSize
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
                     It 'Should return false' {
                         $testParameters = @{
@@ -1007,8 +927,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -1025,8 +943,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
@@ -1037,8 +954,7 @@ try {
                                 MaximumSize = $testMaximumSize
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
                     It 'Should return false' {
                         $testParameters = @{
@@ -1054,8 +970,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -1072,8 +986,7 @@ try {
                     Mock `
                         -CommandName Get-CimInstance `
                         -ParameterFilter $parameterFilterComputerSystem `
-                        -MockWith $mockAutomaticPagefileDisabled `
-                        -Verifiable
+                        -MockWith $mockAutomaticPagefileDisabled
 
                     Mock `
                         -CommandName Get-PageFileSetting `
@@ -1084,8 +997,7 @@ try {
                                 MaximumSize = $testMaximumSize
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
                     It 'Should return false' {
                         $testParameters = @{
@@ -1101,8 +1013,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterComputerSystem `
@@ -1127,10 +1037,9 @@ try {
                                 MaximumSize = $testMaximumSize
                                 Name        = "$testDrive\"
                             }
-                        } `
-                        -Verifiable
+                        }
 
-                    It 'Should not return the expected object' {
+                    It 'Should return the expected object' {
                         $result = Get-PageFileSetting -Drive $testDrive -Verbose
                         $result.InitialSize | Should Be $testInitialSize
                         $result.MaximumSize | Should Be $testMaximumSize
@@ -1138,8 +1047,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Get-CimInstance `
                             -ParameterFilter $parameterFilterPageFileSetting `
@@ -1152,10 +1059,9 @@ try {
                 Context "Set page file settings on drive $testDrive" {
                     Mock `
                         -CommandName Set-CimInstance `
-                        -ParameterFilter $parameterFilterSetPageFileSetting `
-                        -Verifiable
+                        -ParameterFilter $parameterFilterSetPageFileSetting
 
-                    It 'Should not throw exception' {
+                    It 'Should not throw an exception' {
                         {
                             Set-PageFileSetting `
                                 -Drive $testDrive `
@@ -1166,8 +1072,6 @@ try {
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Set-CimInstance `
                             -ParameterFilter $parameterFilterSetPageFileSetting `
@@ -1180,16 +1084,13 @@ try {
                 Context "Enable auto managed page file" {
                     Mock `
                         -CommandName Set-CimInstance `
-                        -ParameterFilter $parameterFilterEnableAutoManagePaging `
-                        -Verifiable
+                        -ParameterFilter $parameterFilterEnableAutoManagePaging
 
-                    It 'Should not throw exception' {
+                    It 'Should not throw an exception' {
                         { Set-AutoManagePaging -State Enable -Verbose } | Should Not Throw
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Set-CimInstance `
                             -ParameterFilter $parameterFilterEnableAutoManagePaging `
@@ -1200,16 +1101,13 @@ try {
                 Context "Disable auto managed page file" {
                     Mock `
                         -CommandName Set-CimInstance `
-                        -ParameterFilter $parameterFilterDisableAutoManagePaging `
-                        -Verifiable
+                        -ParameterFilter $parameterFilterDisableAutoManagePaging
 
-                    It 'Should not throw exception' {
+                    It 'Should not throw an exception' {
                         { Set-AutoManagePaging -State Disable -Verbose } | Should Not Throw
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName Set-CimInstance `
                             -ParameterFilter $parameterFilterDisableAutoManagePaging `
@@ -1222,16 +1120,13 @@ try {
                 Context "Create a new page file" {
                     Mock `
                         -CommandName New-CimInstance `
-                        -ParameterFilter $parameterFilterNewPageFileSetting `
-                        -Verifiable
+                        -ParameterFilter $parameterFilterNewPageFileSetting
 
-                    It 'Should not throw exception' {
+                    It 'Should not throw an exception' {
                         { New-PageFile -PageFileName $testPageFileName -Verbose } | Should Not Throw
                     }
 
                     It 'Should call the correct mocks' {
-                        Assert-VerifiableMocks
-
                         Assert-MockCalled `
                             -CommandName New-CimInstance `
                             -ParameterFilter $parameterFilterNewPageFileSetting `

--- a/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
@@ -41,10 +41,16 @@ try {
             )
         }
 
-        $testDrive = 'D:'
+        $testDrive = 'K:'
         $testInitialSize = 10
         $testMaximumSize = 20
         $testPageFileName = "$testDrive\pagefile.sys"
+
+        $mockGetDriveInfo = {
+            [PSObject] @{
+                Name = "$testDrive\"
+            }
+        }
 
         $mockAutomaticPagefileEnabled = {
             [PSObject] @{
@@ -251,6 +257,26 @@ try {
         }
 
         Describe 'MSFT_xVirtualMemory\Set-TargetResource' {
+            BeforeEach {
+                <#
+                    These mocks are to handle when disk drive
+                    used for testing does not exist.
+                #>
+                Mock `
+                    -CommandName Get-DriveInfo `
+                    -ParameterFilter { $Drive -eq $testDrive } `
+                    -MockWith $mockGetDriveInfo
+
+                Mock `
+                    -CommandName Join-Path `
+                    -ParameterFilter {
+                        $Path -eq "$testDrive\" -and `
+                        $ChildPath -eq 'pagefile.sys'
+                    } `
+                    -MockWith { "$testDrive\pagefile.sys"}
+
+            }
+
             Context 'When automatic managed page file should be enabled' {
                 Mock `
                     -CommandName Get-CimInstance `

--- a/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
@@ -1,6 +1,6 @@
 #region HEADER
-$script:DSCModuleName      = 'xComputerManagement' 
-$script:DSCResourceName    = 'MSFT_xVirtualMemory' 
+$script:DSCModuleName      = 'xComputerManagement'
+$script:DSCResourceName    = 'MSFT_xVirtualMemory'
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -10,7 +10,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
- 
+
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName  `
@@ -29,171 +29,1189 @@ function Invoke-TestCleanup {
 try {
     Invoke-TestSetup
 
-    InModuleScope 'MSFT_xVirtualMemory' {        
+    InModuleScope 'MSFT_xVirtualMemory' {
+        <#
+            Remove-CimInstance overridden to enable PSObject
+            to be passed to mocked version.
+        #>
+        function Remove-CimInstance {
+            param
+            (
+                $InputObject
+            )
+        }
 
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        $testDrive = 'D:'
+        $testInitialSize = 10
+        $testMaximumSize = 20
+        $testPageFileName = "$testDrive\pagefile.sys"
 
+        $mockAutomaticPagefileEnabled = {
+            [PSObject] @{
+                AutomaticManagedPageFile = $true
+                Name = $testPageFileName
+            }
+        }
+
+        $mockAutomaticPagefileDisabled = {
+            [PSObject] @{
+                AutomaticManagedPageFile = $false
+                Name = $testPageFileName
+            }
+        }
+
+        $mockPageFileSetting = {
+            [PSObject] @{
+                Name        = $testPageFileName
+                InitialSize = $testInitialSize
+                MaximumSize = $testMaximumSize
+            }
+        }
+
+        $parameterFilterGetPageFileSetting = {
+            $Drive -eq $testDrive
+        }
+
+        $parameterFilterSetPageFileSetting = {
+            $Namespace -eq 'root\cimv2' -and `
+            $Query -eq "Select * from Win32_PageFileSetting where SettingID='pagefile.sys @ $testDrive'" -and `
+            $Property.InitialSize -eq $testInitialSize -and `
+            $Property.MaximumSize -eq $testMaximumSize
+        }
+
+        $parameterFilterEnableAutoManagePaging = {
+            $Namespace -eq 'root\cimv2' -and `
+            $Query -eq 'Select * from Win32_ComputerSystem' -and `
+            $Property.AutomaticManagedPageFile -eq $True
+        }
+
+        $parameterFilterDisableAutoManagePaging = {
+            $Namespace -eq 'root\cimv2' -and `
+            $Query -eq 'Select * from Win32_ComputerSystem' -and `
+            $Property.AutomaticManagedPageFile -eq $False
+        }
+
+        $parameterFilterNewPageFileSetting = {
+            $Namespace -eq 'root\cimv2' -and `
+            $ClassName -eq 'Win32_PageFileSetting' -and `
+            $Property.Name -eq $testPageFileName
+        }
+
+        $parameterFilterComputerSystem = {
+            $ClassName -eq 'Win32_ComputerSystem'
+        }
+
+        $parameterFilterPageFileSetting = {
+            $ClassName -eq 'Win32_PageFileSetting' -and `
+            $Filter -eq "SettingID='pagefile.sys @ $testDrive'"
+        }
+
+        Describe 'MSFT_xVirtualMemory\Get-TargetResource' {
             BeforeEach {
                 $testParameters = @{
-                    Drive = 'D:'
-                    Type = 'CustomSize'
+                    Drive   = $testDrive
+                    Type    = 'CustomSize'
+                    Verbose = $true
                 }
             }
-        
-            Context 'When the system is in the desired present state' {
-                BeforeEach {
-                    Mock -CommandName Get-CimInstance -MockWith {
-                        [PSObject] @{
-                            AutomaticManagedPageFile = $false
-                            Name = 'D:\pagefile.sys'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
+
+            Context 'When automatic managed page file is enabled' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter $parameterFilterComputerSystem `
+                    -MockWith $mockAutomaticPagefileEnabled `
+                    -Verifiable
+
+                It 'Should return type set to AutoManagePagingFile' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Type | Should Be 'AutoManagePagingFile'
                 }
 
-                It 'It should return the same values as passed as parameters' {
-                    $result = Get-TargetResource @testParameters
-                    $result.Type | Should Be $testParameters.Type
-                    $result.Drive | Should Be ([System.IO.DriveInfo]$testParameters.Drive).Name
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+
+                    Assert-MockCalled `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -Exactly -Times 1
                 }
             }
-            
-            Context 'When the system is not in the desired present state' {
-                BeforeEach {
-                    Mock -CommandName Get-CimInstance -MockWith {
+
+            Context 'When automatic managed page file is disabled and no page file set' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter $parameterFilterComputerSystem `
+                    -MockWith $mockAutomaticPagefileDisabled `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PageFileSetting `
+                    -ParameterFilter $parameterFilterGetPageFileSetting `
+                    -Verifiable
+
+                It 'Should return type set to NoPagingFile' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Type | Should Be 'NoPagingFile'
+                }
+
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+
+                    Assert-MockCalled `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -Exactly -Times 1
+                }
+            }
+
+            Context 'When automatic managed page file is disabled and system managed size is set' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter $parameterFilterComputerSystem `
+                    -MockWith $mockAutomaticPagefileDisabled `
+                    -Verifiable
+
+                Mock `
+                    -CommandName Get-PageFileSetting `
+                    -ParameterFilter $parameterFilterGetPageFileSetting `
+                    -MockWith {
                         [PSObject] @{
                             InitialSize = 0
                             MaximumSize = 0
-                            AutomaticManagedPageFile = $false
-                            Name = "C:\pagefile.sys"
+                            Name        = "$testDrive\"
                         }
-                    } -ModuleName $script:DSCResourceName -Verifiable
+                    } `
+                    -Verifiable
+
+                It 'Should not return a valid type and drive letter' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Type | Should Be 'SystemManagedSize'
+                    $result.Drive | Should Be ([System.IO.DriveInfo] $testParameters.Drive).Name
                 }
 
-                It 'It should not return a valid type' {
-                    $result = Get-TargetResource @testParameters
-                    $result.Type | Should Not Be $testParameters.Type
-                }
-                
-                It 'It should not return a valid drive letter' {
-                    $result = Get-TargetResource @testParameters
-                    $result.Drive | Should Not Be ([System.IO.DriveInfo]$testParameters.Drive).Name
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+
+                    Assert-MockCalled `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -Exactly -Times 1
                 }
             }
 
-            Assert-VerifiableMocks
-        }
-        
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {                   
+            Context 'When automatic managed page file is disabled and custom size is set' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter $parameterFilterComputerSystem `
+                    -MockWith $mockAutomaticPagefileDisabled `
+                    -Verifiable
 
-            Context 'When the system is not in the desired state' {
-                BeforeEach {
-                    $testParameters = @{
-                        Drive = 'C:'
-                        Type = 'CustomSize'
-                        InitialSize = 0
-                        MaximumSize = 1337
-                    }                
-                }    
-                Mock -CommandName Set-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                Mock -CommandName New-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                Mock -CommandName Remove-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                Mock -CommandName Get-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                
-                It 'Should call the mocked function Set-CimInstance exactly once' {
-                    Set-TargetResource @testParameters
-
-                    Assert-MockCalled -CommandName Set-CimInstance -Exactly -Times 1 -Scope It
-                }
-            }
-
-            
-            context 'When an exception is expected' {
-                Mock -CommandName Set-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                Mock -CommandName New-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                Mock -CommandName Remove-CimInstance -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-                Mock -CommandName Get-CimInstance -MockWith {
-                    [PSObject] @{
-                        InitialSize = 0
-                        MaximumSize = 1338
-                        Name = "D:\pagefile.sys"
-                        AutomaticManagedPageFile = $false
+                Mock `
+                    -CommandName Get-PageFileSetting `
+                    -ParameterFilter $parameterFilterGetPageFileSetting `
+                    -MockWith {
+                        [PSObject] @{
+                            InitialSize = 10
+                            MaximumSize = 20
+                            Name        = "$testDrive\"
                         }
+                    } `
+                    -Verifiable
+
+                It 'Should not return a valid type and drive letter' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Type | Should Be 'CustomSize'
+                    $result.Drive | Should Be ([System.IO.DriveInfo] $testParameters.Drive).Name
                 }
 
-                $testParameters = @{
-                    Drive = 'abc'
-                    Type = 'CustomSize'
-                    InitialSize = 0
-                    MaximumSize = 1337
-                } 
-                It 'Should throw if no valid drive letter has been used' {
-                    { Set-TargetResource @testParameters } | Should Throw
-                }
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
 
-                $testParameters = @{
-                    Drive = 'N:'
-                    Type = 'CustomSize'
-                    InitialSize = 0
-                    MaximumSize = 1337
-                } 
-                It 'Should throw if the drive is not ready' {
-                    { Set-TargetResource @testParameters } | Should Throw
+                    Assert-MockCalled `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -Exactly -Times 1
                 }
             }
-
-            Assert-VerifiableMocks
         }
 
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {            
-            Context 'When a True or False is expected' {
-                BeforeEach {
-                    $testParameters = @{
-                        Drive = 'D:'
-                        Type = 'CustomSize'
-                        InitialSize = 0
-                        MaximumSize = 1337
-                    }                
-                }
+        Describe 'MSFT_xVirtualMemory\Set-TargetResource' {
+            Context 'When automatic managed page file should be enabled' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter $parameterFilterComputerSystem `
+                    -MockWith $mockAutomaticPagefileDisabled `
+                    -Verifiable
 
-                $pageFileObject = [PSObject] @{
+                Mock `
+                    -CommandName Set-AutoManagePaging `
+                    -ParameterFilter { $State -eq 'Enable' } `
+                    -Verifiable
+
+                It 'Should not throw exception' {
+                    $testParameters = @{
+                        Drive       = $testDrive
+                        Type        = 'AutoManagePagingFile'
                         InitialSize = 0
-                        MaximumSize = 1338
-                        Name = "D:\pagefile.sys"
-                        AutomaticManagedPageFile = $false
+                        MaximumSize = 0
+                        Verbose     = $true
                     }
-                    
-                Mock -CommandName Get-CimInstance -MockWith {
-                    $pageFileObject.MaximumSize = 1337
-                    $pageFileObject
-                }
-                It 'Should return True if the input matches the actual values' {
-                    Test-TargetResource @testParameters | Should Be $true
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
                 }
 
-                Mock -CommandName Get-CimInstance -MockWith {
-                    $pageFileObject.MaximumSize = 1337
-                    $pageFileObject.AutomaticManagedPageFile = $true
-                    $pageFileObject
+                It 'Should call the correct mocks' {
+                    Assert-VerifiableMocks
+
+                    Assert-MockCalled `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Set-AutoManagePaging `
+                        -ParameterFilter { $State -eq 'Enable' } `
+                        -Exactly -Times 1
                 }
-                It 'Should return False if the type is wrong' {
-                    Test-TargetResource @testParameters | Should Be $false
+            }
+
+            Context 'CustomSize is required' {
+                Context 'When automatic managed page file is enabled and no page file set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileEnabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Set-AutoManagePaging `
+                        -ParameterFilter { $State -eq 'Disable' } `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter { $Drive -eq $testDrive } `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName New-PageFile `
+                        -ParameterFilter { $PageFileName -eq $testPageFileName } `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Set-PageFileSetting `
+                        -ParameterFilter {
+                            $Drive -eq $testDrive -and `
+                            $InitialSize -eq $testInitialSize -and `
+                            $MaximumSize -eq $testMaximumSize
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'CustomSize'
+                            InitialSize = $testInitialSize
+                            MaximumSize = $testMaximumSize
+                            Verbose     = $true
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Set-AutoManagePaging `
+                            -ParameterFilter { $State -eq 'Disable' } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter { $Drive -eq $testDrive } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName New-PageFile `
+                            -ParameterFilter { $PageFileName -eq $testPageFileName } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Set-PageFileSetting `
+                            -ParameterFilter {
+                                $Drive -eq $testDrive -and `
+                                $InitialSize -eq $testInitialSize -and `
+                                $MaximumSize -eq $testMaximumSize
+                            } `
+                            -Exactly -Times 1
+                    }
                 }
 
-                Mock -CommandName Get-CimInstance -MockWith {
-                    $pageFileObject.MaximumSize = 1338
-                    $pageFileObject
-                }
-                It 'Should return False if InitialSize and/or MaximumSize do not match' {
-                    Test-TargetResource @testParameters | Should Be $false
+                Context 'When automatic managed page file is enabled and page file is set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileEnabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Set-AutoManagePaging `
+                        -ParameterFilter { $State -eq 'Disable' } `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter { $Drive -eq $testDrive } `
+                        -MockWith $mockPageFileSetting `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName New-PageFile `
+                        -ParameterFilter { $PageFileName -eq $testPageFileName }
+
+                    Mock `
+                        -CommandName Set-PageFileSetting `
+                        -ParameterFilter {
+                            $Drive -eq $testDrive -and `
+                            $InitialSize -eq $testInitialSize -and `
+                            $MaximumSize -eq $testMaximumSize
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'CustomSize'
+                            InitialSize = $testInitialSize
+                            MaximumSize = $testMaximumSize
+                            Verbose     = $true
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Set-AutoManagePaging `
+                            -ParameterFilter { $State -eq 'Disable' } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter { $Drive -eq $testDrive } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName New-PageFile `
+                            -ParameterFilter { $PageFileName -eq $testPageFileName } `
+                            -Exactly -Times 0
+
+                        Assert-MockCalled `
+                            -CommandName Set-PageFileSetting `
+                            -ParameterFilter {
+                                $Drive -eq $testDrive -and `
+                                $InitialSize -eq $testInitialSize -and `
+                                $MaximumSize -eq $testMaximumSize
+                            } `
+                            -Exactly -Times 1
+                    }
                 }
 
-                Mock -CommandName Get-CimInstance -MockWith {
-                    # In this case Get-CimInstance returns an empty object
-                }
-                It 'Should return False if Name does not match' {
-                    Test-TargetResource @testParameters | Should Be $false
+                Context 'SystemManagedSize is required' {
+                    Context 'When automatic managed page file is enabled and no page file set' {
+                        Mock `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -MockWith $mockAutomaticPagefileEnabled `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName Set-AutoManagePaging `
+                            -ParameterFilter { $State -eq 'Disable' } `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter { $Drive -eq $testDrive } `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName New-PageFile `
+                            -ParameterFilter { $PageFileName -eq $testPageFileName } `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName Set-PageFileSetting `
+                            -ParameterFilter {
+                                $Drive -eq $testDrive
+                            } `
+                            -Verifiable
+
+                        It 'Should return false' {
+                            $testParameters = @{
+                                Drive       = $testDrive
+                                Type        = 'SystemManagedSize'
+                                Verbose     = $true
+                            }
+
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                        }
+
+                        It 'Should call the correct mocks' {
+                            Assert-VerifiableMocks
+
+                            Assert-MockCalled `
+                                -CommandName Get-CimInstance `
+                                -ParameterFilter $parameterFilterComputerSystem `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName Set-AutoManagePaging `
+                                -ParameterFilter { $State -eq 'Disable' } `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName Get-PageFileSetting `
+                                -ParameterFilter { $Drive -eq $testDrive } `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName New-PageFile `
+                                -ParameterFilter { $PageFileName -eq $testPageFileName } `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName Set-PageFileSetting `
+                                -ParameterFilter {
+                                    $Drive -eq $testDrive
+                                } `
+                                -Exactly -Times 1
+                        }
+                    }
                 }
 
+                Context 'When automatic managed page file is enabled and page file is set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileEnabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Set-AutoManagePaging `
+                        -ParameterFilter { $State -eq 'Disable' } `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter { $Drive -eq $testDrive } `
+                        -MockWith $mockPageFileSetting `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName New-PageFile `
+                        -ParameterFilter { $PageFileName -eq $testPageFileName }
+
+                    Mock `
+                        -CommandName Set-PageFileSetting `
+                        -ParameterFilter {
+                            $Drive -eq $testDrive
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'SystemManagedSize'
+                            Verbose     = $true
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Set-AutoManagePaging `
+                            -ParameterFilter { $State -eq 'Disable' } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter { $Drive -eq $testDrive } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName New-PageFile `
+                            -ParameterFilter { $PageFileName -eq $testPageFileName } `
+                            -Exactly -Times 0
+
+                        Assert-MockCalled `
+                            -CommandName Set-PageFileSetting `
+                            -ParameterFilter {
+                                $Drive -eq $testDrive
+                            } `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'NoPagingFile is required' {
+                    Context 'When automatic managed page file is enabled and no page file set' {
+                        Mock `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -MockWith $mockAutomaticPagefileEnabled `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName Set-AutoManagePaging `
+                            -ParameterFilter { $State -eq 'Disable' } `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter { $Drive -eq $testDrive } `
+                            -Verifiable
+
+                        Mock `
+                            -CommandName Remove-CimInstance
+
+                        It 'Should return false' {
+                            $testParameters = @{
+                                Drive       = $testDrive
+                                Type        = 'NoPagingFile'
+                                Verbose     = $true
+                            }
+
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                        }
+
+                        It 'Should call the correct mocks' {
+                            Assert-VerifiableMocks
+
+                            Assert-MockCalled `
+                                -CommandName Get-CimInstance `
+                                -ParameterFilter $parameterFilterComputerSystem `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName Set-AutoManagePaging `
+                                -ParameterFilter { $State -eq 'Disable' } `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName Get-PageFileSetting `
+                                -ParameterFilter { $Drive -eq $testDrive } `
+                                -Exactly -Times 1
+
+                            Assert-MockCalled `
+                                -CommandName Remove-CimInstance `
+                                -Exactly -Times 0
+                        }
+                    }
+                }
+
+                Context 'When automatic managed page file is enabled and page file is set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileEnabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Set-AutoManagePaging `
+                        -ParameterFilter { $State -eq 'Disable' } `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter { $Drive -eq $testDrive } `
+                        -MockWith $mockPageFileSetting `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Remove-CimInstance `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'NoPagingFile'
+                            Verbose     = $true
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Set-AutoManagePaging `
+                            -ParameterFilter { $State -eq 'Disable' } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter { $Drive -eq $testDrive } `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Remove-CimInstance `
+                            -Exactly -Times 1
+                    }
+                }
+            }
+        }
+
+        Describe 'MSFT_xVirtualMemory\Test-TargetResource' {
+            Context 'In desired state' {
+                Context 'With automatic managed page file is enabled' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileEnabled `
+                        -Verifiable
+
+                    It 'Should return true' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'AutoManagePagingFile'
+                            InitialSize = 0
+                            MaximumSize = 0
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'With automatic managed page file is disabled and no page file set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -Verifiable
+
+                    It 'Should return true' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'NoPagingFile'
+                            InitialSize = 0
+                            MaximumSize = 0
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'When automatic managed page file is disabled and system managed size is set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = 0
+                                MaximumSize = 0
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should return true' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'SystemManagedSize'
+                            InitialSize = 0
+                            MaximumSize = 0
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'When automatic managed page file is disabled and custom size is set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = $testInitialSize
+                                MaximumSize = $testMaximumSize
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should return true' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'CustomSize'
+                            InitialSize = $testInitialSize
+                            MaximumSize = $testMaximumSize
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+            }
+
+            Context 'Not in desired state' {
+                Context 'When automatic managed page file is enabled' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'AutoManagePagingFile'
+                            InitialSize = 0
+                            MaximumSize = 0
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'When automatic managed page file is disabled and no page file set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = $testInitialSize
+                                MaximumSize = $testMaximumSize
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'NoPagingFile'
+                            InitialSize = 0
+                            MaximumSize = 0
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'When automatic managed page file is disabled and system managed size is set' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = $testInitialSize
+                                MaximumSize = $testMaximumSize
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'SystemManagedSize'
+                            InitialSize = 0
+                            MaximumSize = 0
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'When automatic managed page file is disabled and custom size is set and initial size differs' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = $testInitialSize
+                                MaximumSize = $testMaximumSize
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'CustomSize'
+                            InitialSize = $testInitialSize + 10
+                            MaximumSize = $testMaximumSize
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context 'When automatic managed page file is disabled and custom size is set and maximum size differs' {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterComputerSystem `
+                        -MockWith $mockAutomaticPagefileDisabled `
+                        -Verifiable
+
+                    Mock `
+                        -CommandName Get-PageFileSetting `
+                        -ParameterFilter $parameterFilterGetPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = $testInitialSize
+                                MaximumSize = $testMaximumSize
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should return false' {
+                        $testParameters = @{
+                            Drive       = $testDrive
+                            Type        = 'CustomSize'
+                            InitialSize = $testInitialSize
+                            MaximumSize = $testMaximumSize + 10
+                            Verbose     = $true
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterComputerSystem `
+                            -Exactly -Times 1
+
+                        Assert-MockCalled `
+                            -CommandName Get-PageFileSetting `
+                            -ParameterFilter $parameterFilterGetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+            }
+
+            Describe 'MSFT_xVirtualMemory\Get-PageFileSetting' {
+                Context "Page file defined on drive $testDrive" {
+                    Mock `
+                        -CommandName Get-CimInstance `
+                        -ParameterFilter $parameterFilterPageFileSetting `
+                        -MockWith {
+                            [PSObject] @{
+                                InitialSize = $testInitialSize
+                                MaximumSize = $testMaximumSize
+                                Name        = "$testDrive\"
+                            }
+                        } `
+                        -Verifiable
+
+                    It 'Should not return the expected object' {
+                        $result = Get-PageFileSetting -Drive $testDrive -Verbose
+                        $result.InitialSize | Should Be $testInitialSize
+                        $result.MaximumSize | Should Be $testMaximumSize
+                        $result.Name | Should Be "$testDrive\"
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Get-CimInstance `
+                            -ParameterFilter $parameterFilterPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+            }
+
+            Describe 'MSFT_xVirtualMemory\Set-PageFileSetting' {
+                Context "Set page file settings on drive $testDrive" {
+                    Mock `
+                        -CommandName Set-CimInstance `
+                        -ParameterFilter $parameterFilterSetPageFileSetting `
+                        -Verifiable
+
+                    It 'Should not throw exception' {
+                        {
+                            Set-PageFileSetting `
+                                -Drive $testDrive `
+                                -InitialSize $testInitialSize `
+                                -MaximumSize $testMaximumSize `
+                                -Verbose
+                         } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Set-CimInstance `
+                            -ParameterFilter $parameterFilterSetPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
+            }
+
+            Describe 'MSFT_xVirtualMemory\Set-AutoManagePaging' {
+                Context "Enable auto managed page file" {
+                    Mock `
+                        -CommandName Set-CimInstance `
+                        -ParameterFilter $parameterFilterEnableAutoManagePaging `
+                        -Verifiable
+
+                    It 'Should not throw exception' {
+                        { Set-AutoManagePaging -State Enable -Verbose } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Set-CimInstance `
+                            -ParameterFilter $parameterFilterEnableAutoManagePaging `
+                            -Exactly -Times 1
+                    }
+                }
+
+                Context "Disable auto managed page file" {
+                    Mock `
+                        -CommandName Set-CimInstance `
+                        -ParameterFilter $parameterFilterDisableAutoManagePaging `
+                        -Verifiable
+
+                    It 'Should not throw exception' {
+                        { Set-AutoManagePaging -State Disable -Verbose } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName Set-CimInstance `
+                            -ParameterFilter $parameterFilterDisableAutoManagePaging `
+                            -Exactly -Times 1
+                    }
+                }
+            }
+
+            Describe 'MSFT_xVirtualMemory\New-PageFile' {
+                Context "Create a new page file" {
+                    Mock `
+                        -CommandName New-CimInstance `
+                        -ParameterFilter $parameterFilterNewPageFileSetting `
+                        -Verifiable
+
+                    It 'Should not throw exception' {
+                        { New-PageFile -PageFileName $testPageFileName -Verbose } | Should Not Throw
+                    }
+
+                    It 'Should call the correct mocks' {
+                        Assert-VerifiableMocks
+
+                        Assert-MockCalled `
+                            -CommandName New-CimInstance `
+                            -ParameterFilter $parameterFilterNewPageFileSetting `
+                            -Exactly -Times 1
+                    }
+                }
             }
         }
     }
@@ -201,4 +1219,3 @@ try {
 finally {
     Invoke-TestCleanup
 }
-


### PR DESCRIPTION
**Pull Request (PR) description**
This PR refactors xVirtualMemory to:
- reduce code duplication
- improve testability (it was very difficult to unit test)
- meet HQRM standards
- increase unit test coverage to 95%
- convert exception calling to use CommonResourceHelper.psm1
- moved strings into localization file

**This Pull Request (PR) fixes the following issues:**
Fixes #95 
Fixes #81

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - sorry about the size of this PR, but once I took a look at the existing code and unit tests, I found it wasn't going to be easy to get decent coverage without refactoring. The same with HQRM - the resource needed a lot of work to get it into decent shape.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/96)
<!-- Reviewable:end -->
