### PR TITLE
Convert xComputer to HQRM and move strings to Localization File - Fixes #101

### DIFF
--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -1,4 +1,4 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Scope = "Function")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Scope = 'Function')]
 param
 (
 )
@@ -441,8 +441,6 @@ function Test-TargetResource
 
     Write-Verbose -Message ($script:localizedData.TestingComputerStateMessage -f $Name)
 
-    Write-Verbose -Message ($script:localizedData.CheckingComputerNameMessage -f $Name)
-
     if (($Name -ne 'localhost') -and ($Name -ne $env:COMPUTERNAME))
     {
         return $false
@@ -490,7 +488,7 @@ function Test-TargetResource
         }
         catch
         {
-            Write-Verbose -Message ($script:localizedData.CheckingNotDomainMemberMessage -f $DomainName)
+            Write-Verbose -Message ($script:localizedData.CheckingNotDomainMemberMessage)
 
             return $false
         }
@@ -545,7 +543,7 @@ function Assert-DomainOrWorkGroup
         Returns the domain the computer is joined to.
 
     .PARAMETER NetBios
-        Specifies if the Net Bios name is returned instead of
+        Specifies if the NetBIOS name is returned instead of
         the fully qualified domain name.
 #>
 function Get-ComputerDomain

--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -331,7 +331,6 @@ function Set-TargetResource
 
         if ($WorkGroupName)
         {
-
             if ($WorkGroupName -eq (Get-CimInstance -Class 'Win32_ComputerSystem').Workgroup)
             {
                 # Same workgroup, new computer name

--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -3,6 +3,36 @@ param
 (
 )
 
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+    -ChildPath 'CommonResourceHelper.psm1')
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xComputer'
+
+<#
+    .SYNOPSIS
+        Gets the current state of the computer.
+
+    .PARAMETER Name
+        The desired computer name.
+
+    .PARAMETER DomainName
+        The name of the domain to join.
+
+    .PARAMETER JoinOU
+        The distinguished name of the organizational unit that the computer
+        account will be created in.
+
+    .PARAMETER Credential
+        Credential to be used to join a domain.
+
+    .PARAMETER UnjoinCredential
+        Credential to be used to leave a domain.
+
+    .PARAMETER WorkGroupName
+        The name of the workgroup.
+
+    .PARAMETER Description
+        The value assigned here will be set as the local computer description.
+#>
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -40,7 +70,7 @@ function Get-TargetResource
         $Description
     )
 
-    Write-Verbose -Message "Getting computer state for '$($Name)'."
+    Write-Verbose -Message ($script:localizedData.GettingComputerStateMessage -f $Name)
 
     $convertToCimCredential = New-CimInstance `
         -ClassName MSFT_Credential `
@@ -55,7 +85,7 @@ function Get-TargetResource
         -ClassName MSFT_Credential `
         -Property @{
             Username = [System.String] $UnjoinCredential.UserName
-            Password = [System.String]$null
+            Password = [System.String] $null
         } `
         -Namespace root/microsoft/windows/desiredstateconfiguration `
         -ClientOnly
@@ -65,15 +95,41 @@ function Get-TargetResource
         DomainName       = Get-ComputerDomain
         JoinOU           = $JoinOU
         CurrentOU        = Get-ComputerOU
-        Credential       = [ciminstance]$convertToCimCredential
-        UnjoinCredential = [ciminstance]$convertToCimUnjoinCredential
+        Credential       = [ciminstance] $convertToCimCredential
+        UnjoinCredential = [ciminstance] $convertToCimUnjoinCredential
         WorkGroupName    = (Get-CimInstance -Class 'Win32_ComputerSystem').Workgroup
         Description      = (Get-CimInstance -Class 'Win32_OperatingSystem').Description
     }
 
-    $returnValue
+    return $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Sets the current state of the computer.
+
+    .PARAMETER Name
+        The desired computer name.
+
+    .PARAMETER DomainName
+        The name of the domain to join.
+
+    .PARAMETER JoinOU
+        The distinguished name of the organizational unit that the computer
+        account will be created in.
+
+    .PARAMETER Credential
+        Credential to be used to join a domain.
+
+    .PARAMETER UnjoinCredential
+        Credential to be used to leave a domain.
+
+    .PARAMETER WorkGroupName
+        The name of the workgroup.
+
+    .PARAMETER Description
+        The value assigned here will be set as the local computer description.
+#>
 function Set-TargetResource
 {
     [CmdletBinding()]
@@ -110,6 +166,8 @@ function Set-TargetResource
         $Description
     )
 
+    Write-Verbose -Message ($script:localizedData.SettingComputerStateMessage -f $Name)
+
     Assert-DomainOrWorkGroup -DomainName $DomainName -WorkGroupName $WorkGroupName
 
     if ($Name -eq 'localhost')
@@ -119,7 +177,7 @@ function Set-TargetResource
 
     if ($PSBoundParameters.ContainsKey('Description'))
     {
-        Write-Verbose -Message "Setting computer description to '$($Description)'."
+        Write-Verbose -Message ($script:localizedData.SettingComputerDescriptionMessage -f $Description)
         $win32OperatingSystemCimInstance = Get-CimInstance -ClassName Win32_OperatingSystem
         $win32OperatingSystemCimInstance.Description = $Description
         Set-CimInstance -InputObject $win32OperatingSystemCimInstance
@@ -133,7 +191,7 @@ function Set-TargetResource
             {
                 # Rename the computer, but stay joined to the domain.
                 Rename-Computer -NewName $Name -DomainCredential $Credential -Force
-                Write-Verbose -Message "Renamed computer to '$($Name)'."
+                Write-Verbose -Message ($script:localizedData.RenamedComputerMessage -f $Name)
             }
             else
             {
@@ -142,40 +200,67 @@ function Set-TargetResource
                     # Rename the computer, and join it to the domain.
                     if ($UnjoinCredential)
                     {
-                        Add-Computer -DomainName $DomainName -Credential $Credential -NewName $Name -UnjoinDomainCredential $UnjoinCredential -Force
+                        Add-Computer `
+                            -DomainName $DomainName `
+                            -Credential $Credential `
+                            -NewName $Name `
+                            -UnjoinDomainCredential $UnjoinCredential `
+                            -Force
                     }
                     else
                     {
                         if ($JoinOU)
                         {
-                            Add-Computer -DomainName $DomainName -Credential $Credential -NewName $Name -OUPath $JoinOU -Force
+                            Add-Computer `
+                                -DomainName $DomainName `
+                                -Credential $Credential `
+                                -NewName $Name `
+                                -OUPath $JoinOU `
+                                -Force
                         }
                         else
                         {
-                            Add-Computer -DomainName $DomainName -Credential $Credential -NewName $Name -Force
+                            Add-Computer `
+                                -DomainName $DomainName `
+                                -Credential $Credential `
+                                -NewName $Name `
+                                -Force
                         }
                     }
-                    Write-Verbose -Message "Renamed computer to '$($Name)' and added to the domain '$($DomainName)."
+
+                    Write-Verbose -Message ($script:localizedData.RenamedComputerAndJoinedDomainMessage -f $Name,$DomainName)
                 }
                 else
                 {
                     # Same computer name, and join it to the domain.
                     if ($UnjoinCredential)
                     {
-                        Add-Computer -DomainName $DomainName -Credential $Credential -UnjoinDomainCredential $UnjoinCredential -Force
+                        Add-Computer `
+                            -DomainName $DomainName `
+                            -Credential $Credential `
+                            -UnjoinDomainCredential $UnjoinCredential `
+                            -Force
                     }
                     else
                     {
                         if ($JoinOU)
                         {
-                            Add-Computer -DomainName $DomainName -Credential $Credential -OUPath $JoinOU -Force
+                            Add-Computer `
+                                -DomainName $DomainName `
+                                -Credential $Credential `
+                                -OUPath $JoinOU `
+                                -Force
                         }
                         else
                         {
-                            Add-Computer -DomainName $DomainName -Credential $Credential -Force
+                            Add-Computer `
+                                -DomainName $DomainName `
+                                -Credential $Credential `
+                                -Force
                         }
                     }
-                    Write-Verbose -Message "Added computer to domain '$($DomainName)."
+
+                    Write-Verbose -Message ($script:localizedData.JoinedDomainMessage -f $DomainName)
                 }
             }
         }
@@ -184,22 +269,33 @@ function Set-TargetResource
             if ($WorkGroupName -eq (Get-CimInstance -Class 'Win32_ComputerSystem').Workgroup)
             {
                 # Rename the computer, but stay in the same workgroup.
-                Rename-Computer -NewName $Name
-                Write-Verbose -Message "Renamed computer to '$($Name)'."
+                Rename-Computer `
+                    -NewName $Name
+
+                Write-Verbose -Message ($script:localizedData.RenamedComputerMessage -f $Name)
             }
             else
             {
                 if ($Name -ne $env:COMPUTERNAME)
                 {
                     # Rename the computer, and join it to the workgroup.
-                    Add-Computer -NewName $Name -Credential $Credential -WorkgroupName $WorkGroupName -Force
-                    Write-Verbose -Message "Renamed computer to '$($Name)' and addded to workgroup '$($WorkGroupName)'."
+                    Add-Computer `
+                        -NewName $Name `
+                        -Credential $Credential `
+                        -WorkgroupName $WorkGroupName `
+                        -Force
+
+                    Write-Verbose -Message ($script:localizedData.RenamedComputerAndJoinedWorkgroupMessage -f $Name,$WorkGroupName)
                 }
                 else
                 {
                     # Same computer name, and join it to the workgroup.
-                    Add-Computer -WorkGroupName $WorkGroupName -Credential $Credential -Force
-                    Write-Verbose -Message "Added computer to workgroup '$($WorkGroupName)'."
+                    Add-Computer `
+                        -WorkGroupName $WorkGroupName `
+                        -Credential $Credential `
+                        -Force
+
+                    Write-Verbose -Message ($script:localizedData.JoinedWorkgroupMessage -f $WorkGroupName)
                 }
             }
         }
@@ -207,13 +303,20 @@ function Set-TargetResource
         {
             if (Get-ComputerDomain)
             {
-                Rename-Computer -NewName $Name -DomainCredential $Credential -Force
-                Write-Verbose -Message "Renamed computer to '$($Name)'."
+                Rename-Computer `
+                    -NewName $Name `
+                    -DomainCredential $Credential `
+                    -Force
+
+                Write-Verbose -Message ($script:localizedData.RenamedComputerMessage -f $Name)
             }
             else
             {
-                Rename-Computer -NewName $Name -Force
-                Write-Verbose -Message "Renamed computer to '$($Name)'."
+                Rename-Computer `
+                    -NewName $Name `
+                    -Force
+
+                Write-Verbose -Message ($script:localizedData.RenamedComputerMessage -f $Name)
             }
         }
     }
@@ -221,30 +324,41 @@ function Set-TargetResource
     {
         if ($DomainName)
         {
-            throw 'Missing domain join credentials.'
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.CredentialsNotSpecifiedError) `
+                -ArgumentName 'Credentials'
         }
+
         if ($WorkGroupName)
         {
 
             if ($WorkGroupName -eq (Get-CimInstance -Class 'Win32_ComputerSystem').Workgroup)
             {
                 # Same workgroup, new computer name
-                Rename-Computer -NewName $Name -force
-                Write-Verbose -Message "Renamed computer to '$($Name)'."
+                Rename-Computer `
+                    -NewName $Name `
+                    -Force
+
+                Write-Verbose -Message ($script:localizedData.RenamedComputerMessage -f $Name)
             }
             else
             {
                 if ($name -ne $env:COMPUTERNAME)
                 {
                     # New workgroup, new computer name
-                    Add-Computer -WorkgroupName $WorkGroupName -NewName $Name
-                    Write-Verbose -Message "Renamed computer to '$($Name)' and added to workgroup '$($WorkGroupName)'."
+                    Add-Computer `
+                        -WorkgroupName $WorkGroupName `
+                        -NewName $Name
+
+                    Write-Verbose -Message ($script:localizedData.RenamedComputerAndJoinedWorkgroupMessage -f $Name,$WorkGroupName)
                 }
                 else
                 {
                     # New workgroup, same computer name
-                    Add-Computer -WorkgroupName $WorkGroupName
-                    Write-Verbose -Message "Added computer to workgroup '$($WorkGroupName)'."
+                    Add-Computer `
+                        -WorkgroupName $WorkGroupName
+
+                    Write-Verbose -Message ($script:localizedData.JoinedWorkgroupMessage -f $WorkGroupName)
                 }
             }
         }
@@ -252,8 +366,10 @@ function Set-TargetResource
         {
             if ($Name -ne $env:COMPUTERNAME)
             {
-                Rename-Computer -NewName $Name
-                Write-Verbose -Message "Renamed computer to '$($Name)'."
+                Rename-Computer `
+                    -NewName $Name
+
+                Write-Verbose -Message ($script:localizedData.RenamedComputerMessage -f $Name)
             }
         }
     }
@@ -261,6 +377,32 @@ function Set-TargetResource
     $global:DSCMachineStatus = 1
 }
 
+<#
+    .SYNOPSIS
+        Tests the current state of the computer.
+
+    .PARAMETER Name
+        The desired computer name.
+
+    .PARAMETER DomainName
+        The name of the domain to join.
+
+    .PARAMETER JoinOU
+        The distinguished name of the organizational unit that the computer
+        account will be created in.
+
+    .PARAMETER Credential
+        Credential to be used to join a domain.
+
+    .PARAMETER UnjoinCredential
+        Credential to be used to leave a domain.
+
+    .PARAMETER WorkGroupName
+        The name of the workgroup.
+
+    .PARAMETER Description
+        The value assigned here will be set as the local computer description.
+#>
 function Test-TargetResource
 {
     [CmdletBinding()]
@@ -298,9 +440,10 @@ function Test-TargetResource
         $Description
     )
 
-    Write-Verbose -Message 'Validate desired Name is a valid name'
+    Write-Verbose -Message ($script:localizedData.TestingComputerStateMessage -f $Name)
 
-    Write-Verbose -Message 'Checking if computer name is correct'
+    Write-Verbose -Message ($script:localizedData.CheckingComputerNameMessage -f $Name)
+
     if (($Name -ne 'localhost') -and ($Name -ne $env:COMPUTERNAME))
     {
         return $false
@@ -308,7 +451,8 @@ function Test-TargetResource
 
     if ($PSBoundParameters.ContainsKey('Description'))
     {
-        Write-Verbose -Message 'Checking if description is corerect'
+        Write-Verbose -Message ($script:localizedData.CheckingComputerDescriptionMessage -f $Description)
+
         if ($Description -ne (Get-CimInstance -Class 'Win32_OperatingSystem').Description)
         {
             return $false
@@ -321,12 +465,14 @@ function Test-TargetResource
     {
         if (-not ($Credential))
         {
-            throw 'Need to specify credentials with domain'
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.CredentialsNotSpecifiedError) `
+                -ArgumentName 'Credentials'
         }
 
         try
         {
-            Write-Verbose "Checking if the machine is a member of $DomainName."
+            Write-Verbose -Message ($script:localizedData.CheckingDomainMemberMessage -f $DomainName)
 
             if ($DomainName.Contains('.'))
             {
@@ -345,14 +491,14 @@ function Test-TargetResource
         }
         catch
         {
-            Write-Verbose 'The machine is not a domain member.'
+            Write-Verbose -Message ($script:localizedData.CheckingNotDomainMemberMessage -f $DomainName)
 
             return $false
         }
     }
     elseif ($WorkGroupName)
     {
-        Write-Verbose -Message "Checking if workgroup name is $WorkGroupName"
+        Write-Verbose -Message ($script:localizedData.CheckingWorkgroupMemberMessage -f $WorkGroupName)
 
         return ($WorkGroupName -eq (Get-CimInstance -Class 'Win32_ComputerSystem').Workgroup)
     }
@@ -363,17 +509,50 @@ function Test-TargetResource
     }
 }
 
-function Assert-DomainOrWorkGroup($DomainName, $WorkGroupName)
+<#
+    .SYNOPSIS
+        Throws an exception if both the domain name and workgroup
+        name is set.
+
+    .PARAMETER DomainName
+        The name of the domain to join.
+
+    .PARAMETER WorkGroupName
+        The name of the workgroup.
+#>
+function Assert-DomainOrWorkGroup
 {
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DomainName,
+
+        [Parameter()]
+        [System.String]
+        $WorkGroupName
+    )
+
     if ($DomainName -and $WorkGroupName)
     {
-        throw 'Only DomainName or WorkGroupName can be specified at once.'
+        New-InvalidOperationException `
+            -Message ($script:localizedData.DomainNameAndWorkgroupNameError)
     }
 }
 
+<#
+    .SYNOPSIS
+        Returns the domain the computer is joined to.
+
+    .PARAMETER NetBios
+        Specifies if the Net Bios name is returned instead of
+        the fully qualified domain name.
+#>
 function Get-ComputerDomain
 {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param
     (
         [Parameter()]
@@ -391,16 +570,27 @@ function Get-ComputerDomain
         {
             $domainName = ([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain()).Name
         }
+
         return $domainName
     }
     catch [System.Management.Automation.MethodInvocationException]
     {
-        Write-Debug 'This machine is not a domain member.'
+        Write-Verbose -Message ($script:localizedData.ComputerNotInDomainMessage)
     }
 }
 
+<#
+    .SYNOPSIS
+        Gets the organisation unit in the domain that the
+        computer account exists in.
+#>
 function Get-ComputerOU
 {
+    [CmdletBinding()]
+    param
+    (
+    )
+
     $ou = $null
 
     if (Get-ComputerDomain)

--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.schema.mof
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.schema.mof
@@ -1,12 +1,12 @@
 [ClassVersion("1.0.1.0"), FriendlyName("xComputer")]
 class MSFT_xComputer : OMI_BaseResource
 {
-    [Key, Description("The desired computer name")] String Name;
-    [Write, Description("The name of the domain to join")] String DomainName;
-    [Write, Description("The distinguished name of the organizational unit that the computer account will be created in")] String JoinOU;
-    [Read, Description("A read-only property that specifies the organizational unit that the computer account is currently in")] String CurrentOU;
-    [Write, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to join or leave domain")] String Credential;
-    [Write, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to join or leave domain")] String UnjoinCredential;
-    [Write, Description("The name of the workgroup")] String WorkGroupName;
-    [Write, Description("The value assigned here will be set as the local computer description")] String Description;
+    [Key, Description("The desired computer name.")] String Name;
+    [Write, Description("The name of the domain to join.")] String DomainName;
+    [Write, Description("The distinguished name of the organizational unit that the computer account will be created in.")] String JoinOU;
+    [Write, Description("Credential to be used to join a domain."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Write, Description("Credential to be used to leave a domain."), EmbeddedInstance("MSFT_Credential")] String UnjoinCredential;
+    [Write, Description("The name of the workgroup.")] String WorkGroupName;
+    [Write, Description("The value assigned here will be set as the local computer description.")] String Description;
+    [Read, Description("A read-only property that specifies the organizational unit that the computer account is currently in.")] String CurrentOU;
 };

--- a/DSCResources/MSFT_xComputer/en-US/MSFT_xComputer.strings.psd1
+++ b/DSCResources/MSFT_xComputer/en-US/MSFT_xComputer.strings.psd1
@@ -9,7 +9,6 @@ ConvertFrom-StringData @'
     JoinedWorkgroupMessage = Added computer to workgroup '{0}'.
     CredentialsNotSpecifiedError = Must to specify credentials with domain.
     TestingComputerStateMessage = Testing computer state for '{0}'.
-    CheckingComputerNameMessage = Checking if computer name is {0}.
     CheckingComputerDescriptionMessage = Checking if computer description is '{0}'.
     CheckingDomainMemberMessage = Checking if the machine is a member of domain '{0}'.
     CheckingNotDomainMemberMessage = Checking if the machine is a not a member of a domain.

--- a/DSCResources/MSFT_xComputer/en-US/MSFT_xComputer.strings.psd1
+++ b/DSCResources/MSFT_xComputer/en-US/MSFT_xComputer.strings.psd1
@@ -1,0 +1,19 @@
+ConvertFrom-StringData @'
+    GettingComputerStateMessage = Getting computer state for '{0}'.
+    SettingComputerStateMessage = Setting computer state for '{0}'.
+    SettingComputerDescriptionMessage = Setting computer description to '{0}'.
+    RenamedComputerMessage = Renamed computer to '{0}'.
+    RenamedComputerAndJoinedDomainMessage = Renamed computer to '{0}' and added to the domain '{1}'.
+    JoinedDomainMessage = Added computer to domain '{0}'.
+    RenamedComputerAndJoinedWorkgroupMessage = Renamed computer to '{0}' and addded to workgroup '{1}'.
+    JoinedWorkgroupMessage = Added computer to workgroup '{0}'.
+    CredentialsNotSpecifiedError = Must to specify credentials with domain.
+    TestingComputerStateMessage = Testing computer state for '{0}'.
+    CheckingComputerNameMessage = Checking if computer name is {0}.
+    CheckingComputerDescriptionMessage = Checking if computer description is '{0}'.
+    CheckingDomainMemberMessage = Checking if the machine is a member of domain '{0}'.
+    CheckingNotDomainMemberMessage = Checking if the machine is a not a member of a domain.
+    CheckingWorkgroupMemberMessage = Checking if the machine is a member of workgroup '{0}'.
+    DomainNameAndWorkgroupNameError = Only DomainName or WorkGroupName can be specified at once.
+    ComputerNotInDomainMessage = This machine is not a domain member.
+'@

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 xComputer resource has following properties:
 
-* Name: The desired computer name
-* DomainName: The name of the domain to join
+* Name: The desired computer name.
+* DomainName: The name of the domain to join.
 * JoinOU: The distinguished name of the organizational unit that the computer
-  account will be created in
-* WorkGroupName: The name of the workgroup
-* Credential: Credential to be used to join or leave domain
+  account will be created in.
+* WorkGroupName: The name of the workgroup.
+* Credential: Credential to be used to join a domain.
+* UnjoinCredential: Credential to be used to leave a domain.
 * CurrentOU: A read-only property that specifies the organizational unit that
-  the computer account is currently in
-* Description: The value assigned here will be set as the local computer description
+  the computer account is currently in.
+* Description: The value assigned here will be set as the local computer description.
 
 ### xComputer Examples
 
@@ -220,6 +221,9 @@ xVirtualMemory has the following properties:
   * Added ConvertTo-TimeSpanFromScheduledTaskString function and refactored
     to reduce code duplication.
   * Added support for setting repetition duration to `Indefinitely`.
+* xComputer:
+  * Moved strings to localization file.
+  * Updated to meet HQRM guidelines.
 
 ### 2.1.0.0
 

--- a/Tests/Unit/MSFT_xComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xComputer.Tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName = 'xComputerManagement'
 $script:DSCResourceName = 'MSFT_xComputer'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
@@ -48,22 +50,29 @@ try
                 }
 
                 It 'Throws if both DomainName and WorkGroupName are specified' {
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.DomainNameAndWorkgroupNameError)
+
                     {
                         Test-TargetResource `
                             -Name $Env:ComputerName `
                             -DomainName 'contoso.com' `
                             -WorkGroupName 'workgroup' `
                             -Verbose
-                    } | Should Throw
+                    } | Should Throw $errorRecord
                 }
 
                 It 'Throws if Domain is specified without Credentials' {
+                    $errorRecord = Get-InvalidArgumentRecord `
+                        -Message ($LocalizedData.CredentialsNotSpecifiedError) `
+                        -ArgumentName 'Credentials'
+
                     {
                         Test-TargetResource `
                             -Name $Env:ComputerName `
                             -DomainName 'contoso.com' `
                             -Verbose
-                    } | Should Throw
+                    } | Should Throw $errorRecord
                 }
 
                 It 'Should return True if Domain name is same as specified' {
@@ -474,25 +483,32 @@ try
                 Mock -CommandName Set-CimInstance
 
                 It 'Throws if both DomainName and WorkGroupName are specified' {
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.DomainNameAndWorkgroupNameError)
+
                     {
                         Set-TargetResource `
                             -Name $Env:ComputerName `
                             -DomainName 'contoso.com' `
                             -WorkGroupName 'workgroup' `
                             -Verbose
-                    } | Should Throw
+                    } | Should Throw $errorRecord
 
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It
                 }
 
                 It 'Throws if Domain is specified without Credentials' {
+                    $errorRecord = Get-InvalidArgumentRecord `
+                        -Message ($LocalizedData.CredentialsNotSpecifiedError) `
+                        -ArgumentName 'Credentials'
+
                     {
                         Set-TargetResource `
                             -Name $Env:ComputerName `
                             -DomainName 'contoso.com' `
                             -Verbose
-                    } | Should Throw
+                    } | Should Throw $errorRecord
 
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It

--- a/Tests/Unit/MSFT_xComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xComputer.Tests.ps1
@@ -55,7 +55,7 @@ try
 
                     {
                         Test-TargetResource `
-                            -Name $Env:ComputerName `
+                            -Name $env:COMPUTERNAME `
                             -DomainName 'contoso.com' `
                             -WorkGroupName 'workgroup' `
                             -Verbose
@@ -69,7 +69,7 @@ try
 
                     {
                         Test-TargetResource `
-                            -Name $Env:ComputerName `
+                            -Name $env:COMPUTERNAME `
                             -DomainName 'contoso.com' `
                             -Verbose
                     } | Should Throw $errorRecord
@@ -89,7 +89,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -DomainName 'Contoso.com' `
                         -Credential $credential `
                         -Verbose | Should Be $true
@@ -109,7 +109,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -WorkGroupName 'workgroup' `
                         -Verbose | Should Be $true
                 }
@@ -128,7 +128,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -DomainName 'contoso.com' `
                         -Credential $credential `
                         -Verbose | Should Be $true
@@ -154,7 +154,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -WorkGroupName 'workgroup' `
                         -Verbose | Should Be $true
 
@@ -178,7 +178,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -Verbose | Should Be $true
 
                     Test-TargetResource `
@@ -198,7 +198,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -Verbose | Should Be $true
 
                     Test-TargetResource `
@@ -254,7 +254,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -DomainName 'adventure-works.com' `
                         -Credential $credential `
                         -Verbose | Should Be $false
@@ -280,7 +280,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -WorkGroupName 'NOTworkgroup' `
                         -Verbose | Should Be $false
 
@@ -341,7 +341,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -DomainName 'contoso.com' `
                         -Credential $credential `
                         -Verbose | Should Be $false
@@ -367,7 +367,7 @@ try
                     }
 
                     Test-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -WorkGroupName 'Contoso' `
                         -Credential $credential `
                         -UnjoinCredential $credential `
@@ -384,7 +384,7 @@ try
                 It 'Throws if name is to long' {
                     {
                         Test-TargetResource `
-                            -Name "ThisNameIsTooLong" `
+                            -Name 'ThisNameIsTooLong' `
                             -Verbose
                     } | Should Throw
                 }
@@ -392,7 +392,7 @@ try
                 It 'Throws if name contains illegal characters' {
                     {
                         Test-TargetResource `
-                            -Name "ThisIsBad<>" `
+                            -Name 'ThisIsBad<>' `
                             -Verbose
                     } | Should Throw
                 }
@@ -400,7 +400,7 @@ try
                 It 'Should not Throw if name is localhost' {
                     {
                         Test-TargetResource `
-                            -Name "localhost" `
+                            -Name 'localhost' `
                             -Verbose
                     } | Should Not Throw
                 }
@@ -463,7 +463,7 @@ try
                 It 'Throws if name is to long' {
                     {
                         Get-TargetResource `
-                            -Name "ThisNameIsTooLong" `
+                            -Name 'ThisNameIsTooLong' `
                             -Verbose
                     } | Should Throw
                 }
@@ -471,7 +471,7 @@ try
                 It 'Throws if name contains illegal characters' {
                     {
                         Get-TargetResource `
-                            -Name "ThisIsBad<>" `
+                            -Name 'ThisIsBad<>' `
                             -Verbose
                     } | Should Throw
                 }
@@ -488,7 +488,7 @@ try
 
                     {
                         Set-TargetResource `
-                            -Name $Env:ComputerName `
+                            -Name $env:COMPUTERNAME `
                             -DomainName 'contoso.com' `
                             -WorkGroupName 'workgroup' `
                             -Verbose
@@ -505,7 +505,7 @@ try
 
                     {
                         Set-TargetResource `
-                            -Name $Env:ComputerName `
+                            -Name $env:COMPUTERNAME `
                             -DomainName 'contoso.com' `
                             -Verbose
                     } | Should Throw $errorRecord
@@ -675,7 +675,7 @@ try
                     }
 
                     Set-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -DomainName 'adventure-works.com' `
                         -Credential $credential `
                         -UnjoinCredential $credential `
@@ -727,7 +727,7 @@ try
                     }
 
                     Set-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -DomainName 'adventure-works.com' `
                         -JoinOU 'OU=Computers,DC=contoso,DC=com' `
                         -Credential $credential `
@@ -781,7 +781,7 @@ try
                     }
 
                     Set-TargetResource `
-                        -Name $Env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -WorkGroupName 'Contoso' `
                         -UnjoinCredential $credential `
                         -Verbose | Should BeNullOrEmpty
@@ -863,7 +863,7 @@ try
                 It 'Throws if name is to long' {
                     {
                         Set-TargetResource `
-                            -Name "ThisNameIsTooLong" `
+                            -Name 'ThisNameIsTooLong' `
                             -Verbose
                     } | Should Throw
                 }
@@ -871,7 +871,7 @@ try
                 It 'Throws if name contains illegal characters' {
                     {
                         Set-TargetResource `
-                            -Name "ThisIsBad<>" `
+                            -Name 'ThisIsBad<>' `
                             -Verbose
                     } | Should Throw
                 }
@@ -912,7 +912,7 @@ try
                     }
 
                     Set-TargetResource `
-                        -Name $env:ComputerName `
+                        -Name $env:COMPUTERNAME `
                         -Verbose | Should BeNullOrEmpty
 
                     Set-TargetResource `

--- a/Tests/Unit/MSFT_xComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xComputer.Tests.ps1
@@ -1,5 +1,5 @@
-$Global:DSCModuleName = 'xComputerManagement'
-$Global:DSCResourceName = 'MSFT_xComputer'
+$script:DSCModuleName = 'xComputerManagement'
+$script:DSCResourceName = 'MSFT_xComputer'
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -22,9 +22,10 @@ try
 {
     #region Pester Tests
 
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
+        $script:DSCResourceName = 'MSFT_xComputer'
 
-        Describe $Global:DSCResourceName {
+        Describe $script:DSCResourceName {
             # A real password isn't needed here - use this next line to avoid triggering PSSA rule
             $securePassword = New-Object -Type SecureString
             $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'USER', $securePassword
@@ -37,7 +38,7 @@ try
                 'name'
             }
 
-            Context "$($Global:DSCResourceName)\Test-TargetResource" {
+            Context "$($script:DSCResourceName)\Test-TargetResource" {
                 Mock -CommandName Get-WMIObject -MockWith {
                     [PSCustomObject] @{
                         DomainName = 'ContosoLtd'
@@ -432,7 +433,7 @@ try
                 }
             }
 
-            Context "$($Global:DSCResourceName)\Get-TargetResource" {
+            Context "$($script:DSCResourceName)\Get-TargetResource" {
                 It 'should not throw' {
                     {
                         Get-TargetResource `
@@ -467,7 +468,7 @@ try
                 }
             }
 
-            Context "$($Global:DSCResourceName)\Set-TargetResource" {
+            Context "$($script:DSCResourceName)\Set-TargetResource" {
                 Mock -CommandName Rename-Computer
                 Mock -CommandName Add-Computer
                 Mock -CommandName Set-CimInstance

--- a/Tests/Unit/MSFT_xOfflineDomainJoin.tests.ps1
+++ b/Tests/Unit/MSFT_xOfflineDomainJoin.tests.ps1
@@ -1,37 +1,38 @@
-$Global:DSCModuleName      = 'xComputerManagement'
-$Global:DSCResourceName    = 'MSFT_xOfflineDomainJoin'
+$script:DSCModuleName      = 'xComputerManagement'
+$script:DSCResourceName    = 'MSFT_xOfflineDomainJoin'
 
-#region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
     #region Pester Tests
 
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
+        $script:DSCResourceName = 'MSFT_xOfflineDomainJoin'
 
         $TestOfflineDomainJoin = @{
             IsSingleInstance = 'Yes'
             RequestFile = 'C:\ODJRequest.txt'
         }
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "$($script:DSCResourceName)\Get-TargetResource" {
 
             It 'should return the correct values' {
                 $Result = Get-TargetResource `
@@ -42,7 +43,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+        Describe "$($script:DSCResourceName)\Set-TargetResource" {
             Mock Test-Path -MockWith { return $True }
             Mock Join-Domain
 
@@ -77,8 +78,8 @@ try
                 }
             }
         }
-        
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+
+        Describe "$($script:DSCResourceName)\Test-TargetResource" {
             Mock Test-Path -MockWith { return $True }
             Mock Get-DomainName -MockWith { return $null }
 
@@ -126,8 +127,8 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Join-Domain" {
-            Mock djoin.exe -MockWith { $Global:LASTEXITCODE = 0; return "OK" }
+        Describe "$($script:DSCResourceName)\Join-Domain" {
+            Mock djoin.exe -MockWith { $script:LASTEXITCODE = 0; return "OK" }
 
             Context 'Domain Join successful' {
                 It 'should not throw' {
@@ -138,7 +139,7 @@ try
                 }
             }
 
-            Mock djoin.exe -MockWith { $Global:LASTEXITCODE = 99; return "ERROR" }
+            Mock djoin.exe -MockWith { $script:LASTEXITCODE = 99; return "ERROR" }
 
             Context 'Domain Join successful' {
                 $errorId = 'DjoinError'

--- a/Tests/Unit/MSFT_xPowerPlan.Tests.ps1
+++ b/Tests/Unit/MSFT_xPowerPlan.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xComputerManagement' 
-$script:DSCResourceName    = 'MSFT_xPowerPlan' 
+$script:DSCModuleName      = 'xComputerManagement'
+$script:DSCResourceName    = 'MSFT_xPowerPlan'
 
 #region HEADER
 
@@ -16,8 +16,7 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
-
+    -TestType Unit
 #endregion HEADER
 
 function Invoke-TestCleanup {
@@ -34,11 +33,11 @@ try
                 Name = 'High performance'
             }
         }
-        
+
         Context 'When the system is in the desired present state' {
             BeforeEach {
                 Mock -CommandName Get-CimInstance -MockWith {
-                    return New-Object Object | 
+                    return New-Object Object |
                         Add-Member -MemberType NoteProperty -Name IsActive -Value $true -PassThru -Force
                 } -ModuleName $script:DSCResourceName -Verifiable
             }
@@ -53,7 +52,7 @@ try
         Context 'When the system is not in the desired present state' {
             BeforeEach {
                 Mock -CommandName Get-CimInstance -MockWith {
-                    return New-Object Object | 
+                    return New-Object Object |
                         Add-Member -MemberType NoteProperty -Name IsActive -Value $false -PassThru -Force
                 } -ModuleName $script:DSCResourceName -Verifiable
             }
@@ -64,7 +63,7 @@ try
                 $result.Name | Should Be $null
             }
         }
-    
+
         Context 'When the Get-CimInstance cannot retrive information about power plans' {
             BeforeEach {
                 Mock -CommandName Get-CimInstance -MockWith {
@@ -152,7 +151,7 @@ try
         Context 'When the system is in the desired present state' {
             BeforeEach {
                 Mock -CommandName Get-CimInstance -MockWith {
-                    return New-Object Object | 
+                    return New-Object Object |
                         Add-Member -MemberType NoteProperty -Name IsActive -Value $true -PassThru -Force
                 } -ModuleName $script:DSCResourceName -Verifiable
             }
@@ -165,7 +164,7 @@ try
         Context 'When the system is not in the desired state' {
             BeforeEach {
                 Mock -CommandName Get-CimInstance -MockWith {
-                    return New-Object Object | 
+                    return New-Object Object |
                         Add-Member -MemberType NoteProperty -Name IsActive -Value $false -PassThru -Force
                 } -ModuleName $script:DSCResourceName -Verifiable
             }

--- a/Tests/Unit/MSFT_xPowerPlan.Tests.ps1
+++ b/Tests/Unit/MSFT_xPowerPlan.Tests.ps1
@@ -1,7 +1,7 @@
 $script:DSCModuleName      = 'xComputerManagement'
 $script:DSCResourceName    = 'MSFT_xPowerPlan'
 
-#region HEADER
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
@@ -5,6 +5,8 @@ param(
 $script:DSCModuleName      = 'xComputerManagement'
 $script:DSCResourceName    = 'MSFT_xScheduledTask'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `

--- a/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
@@ -2,8 +2,8 @@
 param(
 )
 
-$Global:DSCModuleName      = 'xComputerManagement'
-$Global:DSCResourceName    = 'MSFT_xScheduledTask'
+$script:DSCModuleName      = 'xComputerManagement'
+$script:DSCResourceName    = 'MSFT_xScheduledTask'
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
@@ -29,8 +29,10 @@ try
 {
     #region Pester Tests
 
-    InModuleScope $Global:DSCResourceName {
-        Describe $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
+        $script:DSCResourceName = 'MSFT_xScheduledTask'
+
+        Describe $script:DSCResourceName {
             BeforeAll {
                 Mock -CommandName Register-ScheduledTask
                 Mock -CommandName Set-ScheduledTask

--- a/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
@@ -5,23 +5,21 @@ param(
 $Global:DSCModuleName      = 'xComputerManagement'
 $Global:DSCResourceName    = 'MSFT_xScheduledTask'
 
-
-
-#region HEADER
-# Unit Test Template Version: 1.1.0
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
-#endregion
+#endregion HEADER
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 

--- a/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xVirtualMemory.Tests.ps1
@@ -2,6 +2,8 @@
 $script:DSCModuleName      = 'xComputerManagement'
 $script:DSCResourceName    = 'MSFT_xVirtualMemory'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
@@ -15,7 +17,6 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName  `
     -TestType Unit
-
 #endregion HEADER
 
 function Invoke-TestSetup {


### PR DESCRIPTION
**Pull Request (PR) description**
Convert xComputer resource to HQRM standards and move strings to Localization file.

**This Pull Request (PR) fixes the following issues:**
- Fixes #101 
- Work on #94 
- Work on #80

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - would you mind reviewing if you get time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/102)
<!-- Reviewable:end -->
