### PR TITLE
xComputer: Fixes #44

### DIFF
--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -578,9 +578,10 @@ function Get-ComputerDomain
         }
         else
         {
-            if((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain -eq $true)
+            $domainInfo = Get-CimInstance -Class Win32_ComputerSystem
+            if ($domainInfo.PartOfDomain -eq $true)
             {
-                $domainName = (Get-WmiObject -Class Win32_ComputerSystem).Domain
+                $domainName = $domainInfo.Domain
             }
             else
             {

--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -572,21 +572,21 @@ function Get-ComputerDomain
 
     try
     {
-        if ($NetBios)
+        $domainInfo = Get-CimInstance -ClassName Win32_ComputerSystem
+        if ($domainInfo.PartOfDomain -eq $true)
         {
-            $domainName = $ENV:USERDOMAIN
-        }
-        else
-        {
-            $domainInfo = Get-CimInstance -Class Win32_ComputerSystem
-            if ($domainInfo.PartOfDomain -eq $true)
+            if ($NetBios)
             {
-                $domainName = $domainInfo.Domain
+                $domainName = (Get-Item -Path Env:\USERDOMAIN).Value
             }
             else
             {
-                $domainName = $null
+                $domainName = $domainInfo.Domain
             }
+        }
+        else
+        {
+            $domainName = ""
         }
 
         return $domainName

--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -586,7 +586,7 @@ function Get-ComputerDomain
         }
         else
         {
-            $domainName = ""
+            $domainName = ''
         }
 
         return $domainName

--- a/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
+++ b/DSCResources/MSFT_xComputer/MSFT_xComputer.psm1
@@ -578,7 +578,14 @@ function Get-ComputerDomain
         }
         else
         {
-            $domainName = ([System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain()).Name
+            if((Get-WmiObject -Class Win32_ComputerSystem).PartOfDomain -eq $true)
+            {
+                $domainName = (Get-WmiObject -Class Win32_ComputerSystem).Domain
+            }
+            else
+            {
+                $domainName = $null
+            }
         }
 
         return $domainName

--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ xVirtualMemory has the following properties:
     task execution.
   * Correct `Assert-VerifiableMocks` to `Assert-VerifiableMock`
 
-* xComputer
-  * Resolved bug in Get-ComputerDomain where LocalSystem doesn't have rights to the domain
+* xComputer:
+  * Resolved bug in Get-ComputerDomain where LocalSystem doesn't have
+  rights to the domain
 
 ### 3.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ xVirtualMemory has the following properties:
     task execution.
   * Correct `Assert-VerifiableMocks` to `Assert-VerifiableMock`
 
+* xComputer
+  * Resolved bug in Get-ComputerDomain where LocalSystem doesn't have rights to the domain
+
 ### 3.0.0.0
 
 * xComputer: Added parameter to set the local computer description along with documentation

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ xVirtualMemory has the following properties:
   * Fix error message when trigger type is unknown - See [Issue #121](https://github.com/PowerShell/xComputerManagement/issues/121).
   * Moved strings into separate strings file.
   * Updated to meet HQRM guidelines.
+* xComputer:
+  * Resolved bug in Get-ComputerDomain where LocalSystem doesn't have
+  rights to the domain
 
 ### 3.2.0.0
 
@@ -246,10 +249,6 @@ xVirtualMemory has the following properties:
   * Added LogonType and RunLevel parameters for controlling
     task execution.
   * Correct `Assert-VerifiableMocks` to `Assert-VerifiableMock`
-
-* xComputer:
-  * Resolved bug in Get-ComputerDomain where LocalSystem doesn't have
-  rights to the domain
 
 ### 3.0.0.0
 

--- a/Tests/Unit/MSFT_xComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xComputer.Tests.ps1
@@ -928,15 +928,15 @@ try
             }
 
             Context "$($script:DSCResourceName)\Get-ComputerDomain" {
-                It "returns domain netbios or DNS name if domain member" {
-                    Mock -CommandName Get-CimInstance -ParameterFilter {$ClassName -eq "Win32_ComputerSystem"} -MockWith {
+                It 'Returns domain netbios or DNS name if domain member' {
+                    Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -MockWith {
                         [PSCustomObject] @{
                             Domain       = 'contoso.com';
                             PartOfDomain = $true
                         }
                     }
 
-                    Mock -CommandName Get-Item -ParameterFilter {$Path -eq "Env:\USERDOMAIN"} -MockWith {
+                    Mock -CommandName Get-Item -ParameterFilter { $Path -eq 'Env:\USERDOMAIN' } -MockWith {
                         [PSCustomObject] @{
                             Value = 'CONTOSO'
                         }
@@ -946,27 +946,27 @@ try
                         netbios = $true
                     }
 
-                    Get-ComputerDomain @getComputerDomainParameters | Should Be "CONTOSO"
+                    Get-ComputerDomain @getComputerDomainParameters | Should Be 'CONTOSO'
 
                     $getComputerDomainParameters = @{
                         netbios = $false
                     }
 
-                    Get-ComputerDomain @getComputerDomainParameters | Should Be "contoso.com"
+                    Get-ComputerDomain @getComputerDomainParameters | Should Be 'contoso.com'
 
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                     Assert-MockCalled -CommandName Get-Item -Exactly -Times 1 -Scope It
                 }
 
-                It "returns nothing if in a workgroup" {
-                    Mock -CommandName Get-CimInstance -ParameterFilter {$ClassName -eq "Win32_ComputerSystem"} -MockWith {
+                It 'Returns nothing if in a workgroup' {
+                    Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -MockWith {
                         [PSCustomObject] @{
                             Domain       = 'WORKGROUP';
                             PartOfDomain = $false
                         }
                     }
 
-                    Mock -CommandName Get-Item -ParameterFilter {$Path -eq "Env:\USERDOMAIN"} -MockWith {
+                    Mock -CommandName Get-Item -ParameterFilter { $Path -eq 'Env:\USERDOMAIN' } -MockWith {
                         [PSCustomObject] @{
                             Value = 'Computer1'
                         }
@@ -976,27 +976,27 @@ try
                         netbios = $true
                     }
 
-                    Get-ComputerDomain @getComputerDomainParameters | Should Be ""
+                    Get-ComputerDomain @getComputerDomainParameters | Should Be ''
 
                     $getComputerDomainParameters = @{
                         netbios = $false
                     }
 
-                    Get-ComputerDomain @getComputerDomainParameters | Should Be ""
+                    Get-ComputerDomain @getComputerDomainParameters | Should Be ''
 
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 2 -Scope It
                     Assert-MockCalled -CommandName Get-Item -Exactly -Times 0 -Scope It
                 }
 
                 It "returns domain DNS name when netbios not specified" {
-                    Mock -CommandName Get-CimInstance -ParameterFilter {$ClassName -eq "Win32_ComputerSystem"} -MockWith {
+                    Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -MockWith {
                         [PSCustomObject] @{
                             Domain       = 'contoso.com';
                             PartOfDomain = $true
                         }
                     }
 
-                    Mock -CommandName Get-Item -ParameterFilter {$Path -eq "Env:\USERDOMAIN"} -MockWith {
+                    Mock -CommandName Get-Item -ParameterFilter { $Path -eq 'Env:\USERDOMAIN' } -MockWith {
                         [PSCustomObject] @{
                             Value = 'CONTOSO'
                         }

--- a/Tests/Unit/MSFT_xComputer.Tests.ps1
+++ b/Tests/Unit/MSFT_xComputer.Tests.ps1
@@ -988,7 +988,7 @@ try
                     Assert-MockCalled -CommandName Get-Item -Exactly -Times 0 -Scope It
                 }
 
-                It "returns domain DNS name when netbios not specified" {
+                It 'Returns domain DNS name when netbios not specified' {
                     Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_ComputerSystem' } -MockWith {
                         [PSCustomObject] @{
                             Domain       = 'contoso.com';


### PR DESCRIPTION
**Pull Request (PR) description**
Pull Request to fix issue 44 with xComputer.psm1 where the Get-ComputerDomain function uses a command which LocalSystem doesn't have rights to. Changed to use this instead:

`Get-WmiObject -Class Win32_ComputerSystem`

**This Pull Request (PR) fixes the following issues:**
Fixes #44

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/113)
<!-- Reviewable:end -->
