### PR TITLE
Fix ExecutionTimeLimit to Enable No Limit - Fixes #115

### DIFF
--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -915,7 +915,7 @@ function Set-TargetResource
             $settingParameters.Add('IdleWaitTimeout', $IdleWaitTimeout)
         }
 
-        if ($ExecutionTimeLimit -gt [System.TimeSpan] '00:00:00')
+        if ($PSBoundParameters.ContainsKey('ExecutionTimeLimit'))
         {
             $settingParameters.Add('ExecutionTimeLimit', $ExecutionTimeLimit)
         }

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -932,6 +932,17 @@ function Set-TargetResource
 
         $setting = New-ScheduledTaskSettingsSet @settingParameters
 
+        <#
+            On Windows Server 2012 R2 setting a blank timespan for ExecutionTimeLimit
+            does not result in the PT0S timespan value being set. So set this
+            if it has not been set.
+        #>
+        if ($PSBoundParameters.ContainsKey('ExecutionTimeLimit') -and `
+            [System.String]::IsNullOrEmpty($setting.ExecutionTimeLimit))
+        {
+            $setting.ExecutionTimeLimit = 'PT0S'
+        }
+
         $triggerParameters = @{}
 
         if ($RandomDelay -gt [System.TimeSpan]::FromSeconds(0))

--- a/Examples/xScheduledTask/1-CreateScheduledTaskOnce.ps1
+++ b/Examples/xScheduledTask/1-CreateScheduledTaskOnce.ps1
@@ -4,7 +4,8 @@
     task folder 'MyTasks' that starts a new powershell process once at 00:00 repeating
     every 15 minutes for 8 hours. The task is delayed by a random amount up to 1 hour
     each time. The task will run even if the previous task is still running and it
-    will prevent hard termintaing of the previously running task instance.
+    will prevent hard termintaing of the previously running task instance. The task
+    execution will have no time limit.
 #>
 Configuration Example
 {
@@ -27,6 +28,7 @@ Configuration Example
             ScheduleType          = 'Once'
             RepeatInterval        = '00:15:00'
             RepetitionDuration    = '08:00:00'
+            ExecutionTimeLimit    = '00:00:00'
             ActionWorkingPath     = (Get-Location).Path
             Enable                = $true
             RandomDelay           = '01:00:00'

--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ xVirtualMemory has the following properties:
 
 ### Unreleased
 
+* xScheduledTask:
+  * Enable Execution Time Limit of task to be set to indefinite
+    by setting `ExecutionTimeLimit` to '00:00:00' - See [Issue #115](https://github.com/PowerShell/xComputerManagement/issues/115)
+
 ### 3.1.0.0
 
 * xOfflineDomainJoin:

--- a/Tests/Integration/MSFT_xScheduledTask.Config.ps1
+++ b/Tests/Integration/MSFT_xScheduledTask.Config.ps1
@@ -17,6 +17,7 @@ Configuration xScheduledTaskOnceCrossTimezone
             DisallowHardTerminate = $true
             RunOnlyIfIdle         = $false
             Priority              = 9
+            ExecutionTimeLimit    = '00:00:00'
         }
     }
 }
@@ -181,7 +182,7 @@ Configuration xScheduledTaskOnceMod
             RepeatInterval      = '00:20:00'
             RepetitionDuration  = '08:00:00'
             DisallowDemandStart = $true
-            ExecutionTimeLimit    = '02:00:00'
+            ExecutionTimeLimit  = '02:00:00'
         }
     }
 }

--- a/Tests/Integration/MSFT_xScheduledTask.Config.ps1
+++ b/Tests/Integration/MSFT_xScheduledTask.Config.ps1
@@ -40,6 +40,7 @@ Configuration xScheduledTaskOnceAdd
             DisallowHardTerminate = $true
             RunOnlyIfIdle         = $false
             Priority              = 9
+            ExecutionTimeLimit    = '00:00:00'
         }
     }
 }
@@ -180,6 +181,7 @@ Configuration xScheduledTaskOnceMod
             RepeatInterval      = '00:20:00'
             RepetitionDuration  = '08:00:00'
             DisallowDemandStart = $true
+            ExecutionTimeLimit    = '02:00:00'
         }
     }
 }

--- a/Tests/Integration/MSFT_xScheduledTask.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScheduledTask.Integration.Tests.ps1
@@ -186,6 +186,7 @@ try
                 $current.RunOnlyIfIdle         | Should Be $false
                 $current.Priority              | Should Be 9
                 $current.RunLevel              | Should Be 'Limited'
+                $current.ExecutionTimeLimit    | Should Be '00:00:00'
             }
 
             AfterAll {

--- a/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
@@ -179,8 +179,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -267,8 +267,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -354,8 +354,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -439,8 +439,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -490,8 +490,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -541,8 +541,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -590,8 +590,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -639,8 +639,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -691,8 +691,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
 
             }
@@ -746,8 +746,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -902,8 +902,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -1031,8 +1031,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -1093,8 +1093,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -1141,8 +1141,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 
@@ -1189,8 +1189,8 @@ try
 
                 It 'Should update the scheduled task in the set method' {
                     Set-TargetResource @testParameters
-                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Times 1
-                    Assert-Mockcalled -CommandName Register-ScheduledTask -Times 1
+                    Assert-MockCalled -CommandName Unregister-ScheduledTask -Exactly -Times 1
+                    Assert-Mockcalled -CommandName Register-ScheduledTask -Exactly -Times 1
                 }
             }
 


### PR DESCRIPTION
**Pull Request (PR) description**
This PR enables setting the ExecutionTimeLimit to no limit (indefinite) by setting the parameter to '00:00:00'. Note: setting ExecutionTimeLimit has to be done differently on Windows Server 2012 R2 and Windows Server 2016/Windows 10, so I've added code to handle them all.

**This Pull Request (PR) fixes the following issues:**
#115

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - if you wouldn't mind and have the time would you be able to review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/118)
<!-- Reviewable:end -->
