### PR TITLE
xScheduledTask: Move strings to localization file and HQRM - fixes #125

### DIFF
--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -28,7 +28,7 @@ Import-Module -Name (Join-Path -Path $modulePath `
 
 # Import Localization Strings
 $script:localizedData = Get-LocalizedData `
-    -ResourceName 'MSFT_xVirtualMemory' `
+    -ResourceName 'MSFT_xScheduledTask' `
     -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
 
 <#

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -510,8 +510,8 @@ function Get-TargetResource
             RestartCount                    = $settings.RestartCount
             RestartInterval                 = ConvertTo-TimeSpanStringFromScheduledTaskString -TimeSpan $settings.RestartInterval
             RunOnlyIfNetworkAvailable       = $settings.RunOnlyIfNetworkAvailable
-            RunLevel                        = [String] $task.Principal.RunLevel
-            LogonType                       = [String] $task.Principal.LogonType
+            RunLevel                        = [System.String] $task.Principal.RunLevel
+            LogonType                       = [System.String] $task.Principal.LogonType
         }
     }
 }
@@ -1110,7 +1110,7 @@ function Set-TargetResource
             $registerArguments.Add('User', $username)
 
             # If the LogonType is not specified then set it to password
-            if ([String]::IsNullOrEmpty($LogonType))
+            if ([System.String]::IsNullOrEmpty($LogonType))
             {
                 $LogonType = 'Password'
             }
@@ -1156,6 +1156,7 @@ function Set-TargetResource
         if ($currentValues.Ensure -eq 'Present')
         {
             Write-Verbose -Message ($script:localizedData.RemovePreviousScheduledTaskMessage -f $TaskName, $TaskPath)
+
             $null = Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Confirm:$false -ErrorAction Stop
         }
 
@@ -1167,6 +1168,7 @@ function Set-TargetResource
         if ($repetition)
         {
             Write-Verbose -Message ($script:localizedData.SetRepetitionTriggerMessage -f $TaskName, $TaskPath)
+
             $scheduledTask.Triggers[0].Repetition = $repetition
         }
 
@@ -1179,6 +1181,7 @@ function Set-TargetResource
         $registerArguments.Add('InputObject', $scheduledTask)
 
         Write-Verbose -Message ($script:localizedData.RegisterScheduledTaskMessage -f $TaskName, $TaskPath)
+
         $null = Register-ScheduledTask @registerArguments -ErrorAction Stop
     }
 
@@ -1694,7 +1697,7 @@ function ConvertTo-TimeSpanStringFromScheduledTaskString
     )
 
     # If AllowIndefinitely is true and the timespan is empty then return Indefinitely
-    if ($AllowIndefinitely -eq $true -and [String]::IsNullOrEmpty($TimeSpan))
+    if ($AllowIndefinitely -eq $true -and [System.String]::IsNullOrEmpty($TimeSpan))
     {
         return 'Indefinitely'
     }

--- a/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
+++ b/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
@@ -6,8 +6,8 @@ ConvertFrom-StringData @'
     DetectedScheduleTypeMessage = Detected schedule type '{0}' for first trigger.
     SetScheduledTaskMessage = Setting scheduled task '{0}' in '{1}'.
     RepetitionDurationLessThanIntervalError = Repetition duration '{0}' is less than repetition interval '{1}'. Please set RepeatInterval to a value lower or equal to RepetitionDuration.
-    DaysIntervalError = DaysInterval must be greater than 0 for Daily schedules. DaysInterval specified is '{0}'.
-    WeeksIntervalError = WeeksInterval must be greater than 0 for Weekly schedules. WeeksInterval specified is '{0}'.
+    DaysIntervalError = DaysInterval must be greater than zero (0) for Daily schedules. DaysInterval specified is '{0}'.
+    WeeksIntervalError = WeeksInterval must be greater than zero (0) for Weekly schedules. WeeksInterval specified is '{0}'.
     WeekDayMissingError = At least one weekday must be selected for Weekly schedule.
     TriggerCreationError = Error creating new scheduled task trigger.
     ConfigureTriggerRepetitionMessage = Configuring trigger repetition.

--- a/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
+++ b/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
@@ -1,0 +1,29 @@
+ConvertFrom-StringData @'
+    GetScheduledTaskMessage = Getting scheduled task '{0}' in '{1}'.
+    TaskNotFoundMessage = Task '{0}' not found in '{1}'. Returning an empty task with Ensure = "Absent".
+    TaskFoundMessage = Task '{0}' found in '{1}'. Retrieving settings, first action, first trigger and repetition settings.
+    TriggerTypeError = Trigger type '{0}' not recognized.
+    DetectedScheduleTypeMessage = Detected schedule type '{0}' for first trigger.
+    SetScheduledTaskMessage = Setting scheduled task '{0}' in '{1}'.
+    RepetitionDurationLessThanIntervalError = Repetition duration '{0}' is less than repetition interval '{1}'. Please set RepeatInterval to a value lower or equal to RepetitionDuration.
+    DaysIntervalError = DaysInterval must be greater than 0 for Daily schedules. DaysInterval specified is '{0}'.
+    WeeksIntervalError = WeeksInterval must be greater than 0 for Weekly schedules. WeeksInterval specified is '{0}'.
+    WeekDayMissingError = At least one weekday must be selected for Weekly schedule.
+    TriggerCreationError = Error creating new scheduled task trigger.
+    ConfigureTriggerRepetitionMessage = Configuring trigger repetition.
+    RepetitionIntervalError = Repetition interval is set to '{0}' but repetition duration is '{1}'.
+    CreateRepetitionPatternMessage = Creating MSFT_TaskRepetitionPattern CIM instance to configure repetition in trigger.
+    CreateTemporaryTaskMessage = Creating temporary task and trigger to get MSFT_TaskRepetitionPattern CIM instance.
+    CreateTemporaryTriggerMessage = Creating temporary trigger to get MSFT_TaskRepetitionPattern CIM instance.
+    TriggerUnexpectedTypeError = Trigger object that was created was of unexpected type '{0}'.
+    CreateScheduledTaskPrincipalMessage = Creating scheduled task principal for account '{0}' using logon type '{1}'.
+    RemovePreviousScheduledTaskMessage = Removing previous scheduled task '{0}' from '{1}'.
+    CreateNewScheduledTaskMessage = Creating new scheduled task '{0}' in '{1}'.
+    SetRepetitionTriggerMessage = Setting repetition trigger settings on task '{0}' in '{1}'.
+    RegisterScheduledTaskMessage = Registering the scheduled task '{0}' in '{1}'.
+    RemoveScheduledTaskMessage = Removing scheduled task '{0}' from '{1}'.
+    TestScheduledTaskMessage = Testing scheduled task '{0}' in '{1}'.
+    GetCurrentTaskValuesMessage = Current scheduled task values retrieved.
+    CurrentTaskValuesNullMessage = Current scheduled values were null.
+    TestingDscParameterStateMessage = Testing DSC parameter state.
+'@

--- a/README.md
+++ b/README.md
@@ -217,11 +217,16 @@ xVirtualMemory has the following properties:
 
 ### Unreleased
 
+* xScheduledTask:
+  * Fix error message when trigger type is unknown - See [Issue #121](https://github.com/PowerShell/xComputerManagement/issues/121).
+  * Moved strings into separate strings file.
+  * Updated to meet HQRM guidelines.
+
 ### 3.2.0.0
 
 * xScheduledTask:
   * Enable Execution Time Limit of task to be set to indefinite
-    by setting `ExecutionTimeLimit` to '00:00:00' - See [Issue #115](https://github.com/PowerShell/xComputerManagement/issues/115)
+    by setting `ExecutionTimeLimit` to '00:00:00' - See [Issue #115](https://github.com/PowerShell/xComputerManagement/issues/115).
 * xPowerPlan:
   * Updated to meet HQRM guidelines.
   * Converted calls to `throw` to use `New-InvalidOperationException`


### PR DESCRIPTION
**Pull Request (PR) description**
Convert xScheduledTask to HQRM and move strings to Localization File. Also correct message produced when existing scheduled task trigger type is not recognized.

**This Pull Request (PR) fixes the following issues:**
- Fixes #125
- Fixes #121

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - this is the last HQRM change required to this module. Would you mind reviewing if you get a chance? I can then get onto the rename and starting work on adding features again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/126)
<!-- Reviewable:end -->
