### PR TITLE
BREAKING CHANGE: xScheduledTask: Add support for disabling built-in tasks - Fixes #74

### DIFF
--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -220,7 +220,7 @@ function Get-TargetResource
         [System.String]
         $Description,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $ActionExecutable,
 
@@ -232,7 +232,7 @@ function Get-TargetResource
         [System.String]
         $ActionWorkingPath,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         [ValidateSet('Once', 'Daily', 'Weekly', 'AtStartup', 'AtLogOn')]
         $ScheduleType,
@@ -390,10 +390,9 @@ function Get-TargetResource
         Write-Verbose -Message ($script:localizedData.TaskNotFoundMessage -f $TaskName, $TaskPath)
 
         return @{
-            TaskName         = $TaskName
-            ActionExecutable = $ActionExecutable
-            Ensure           = 'Absent'
-            ScheduleType     = $ScheduleType
+            TaskName = $TaskName
+            TaskPath = $task.TaskPath
+            Ensure   = 'Absent'
         }
     }
     else
@@ -685,7 +684,7 @@ function Set-TargetResource
         [System.String]
         $Description,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $ActionExecutable,
 
@@ -697,7 +696,7 @@ function Set-TargetResource
         [System.String]
         $ActionWorkingPath,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         [ValidateSet('Once', 'Daily', 'Weekly', 'AtStartup', 'AtLogOn')]
         $ScheduleType,
@@ -1363,7 +1362,7 @@ function Test-TargetResource
         [System.String]
         $Description,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $ActionExecutable,
 
@@ -1375,7 +1374,7 @@ function Test-TargetResource
         [System.String]
         $ActionWorkingPath,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         [ValidateSet('Once', 'Daily', 'Weekly', 'AtStartup', 'AtLogOn')]
         $ScheduleType,

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -1779,5 +1779,5 @@ function Disable-ScheduledTask
 
     $existingTask = Get-ScheduledTask @PSBoundParameters
     $existingTask.Settings.Enabled = $false
-    $null = $existingTask | Register-ScheduledTask -Force
+    $null = $existingTask | Register-ScheduledTask @PSBoundParameters -Force
 }

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -1624,7 +1624,7 @@ function Test-TargetResource
 
     Write-Verbose -Message ($script:localizedData.TestingDscParameterStateMessage)
 
-    return Test-DscParameterState -CurrentValues $currentValues -DesiredValues $desiredValues -Verbose
+    return Test-DscParameterState -CurrentValues $currentValues -DesiredValues $desiredValues
 }
 
 <#

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -1624,7 +1624,7 @@ function Test-TargetResource
 
     Write-Verbose -Message ($script:localizedData.TestingDscParameterStateMessage)
 
-    return Test-DscParameterState -CurrentValues $currentValues -DesiredValues $desiredValues
+    return Test-DscParameterState -CurrentValues $currentValues -DesiredValues $desiredValues -Verbose
 }
 
 <#

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -1778,7 +1778,6 @@ function Disable-ScheduledTask
     )
 
     $existingTask = Get-ScheduledTask @PSBoundParameters
-    Write-Verbose -Verbose -Message ($existingTask.Settings.Enabled | Out-String)
     $existingTask.Settings.Enabled = $false
     $null = $existingTask | Register-ScheduledTask -Force
 }

--- a/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.schema.mof
+++ b/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.schema.mof
@@ -4,10 +4,10 @@ class MSFT_xScheduledTask : OMI_BaseResource
     [Key, Description("The name of the task")] string TaskName;
     [Write, Description("The path to the task - defaults to the root directory")] string TaskPath;
     [Write, Description("The task description")] string Description;
-    [Required, Description("The path to the .exe for this task")] string ActionExecutable;
+    [Write, Description("The path to the .exe for this task")] string ActionExecutable;
     [Write, Description("The arguments to pass the executable")] string ActionArguments;
     [Write, Description("The working path to specify for the executable")] string ActionWorkingPath;
-    [Required, Description("When should the task be executed"), ValueMap{"Once", "Daily", "Weekly", "AtStartup", "AtLogOn"}, Values{"Once", "Daily", "Weekly", "AtStartup", "AtLogOn"}] string ScheduleType;
+    [Write, Description("When should the task be executed"), ValueMap{"Once", "Daily", "Weekly", "AtStartup", "AtLogOn"}, Values{"Once", "Daily", "Weekly", "AtStartup", "AtLogOn"}] string ScheduleType;
     [Write, Description("How many units (minutes, hours, days) between each run of this task?")] String RepeatInterval;
     [Write, Description("The time of day this task should start at - defaults to 12:00 AM. Not valid for AtLogon and AtStartup tasks")] DateTime StartTime;
     [Write, Description("Present if the task should exist, Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;

--- a/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
+++ b/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
@@ -5,6 +5,7 @@ ConvertFrom-StringData @'
     TriggerTypeError = Trigger type '{0}' not recognized.
     DetectedScheduleTypeMessage = Detected schedule type '{0}' for first trigger.
     SetScheduledTaskMessage = Setting scheduled task '{0}' in '{1}'.
+    DisablingExistingScheduledTask = Disabling existing scheduled task '{0}' in '{1}'.
     RepetitionDurationLessThanIntervalError = Repetition duration '{0}' is less than repetition interval '{1}'. Please set RepeatInterval to a value lower or equal to RepetitionDuration.
     DaysIntervalError = DaysInterval must be greater than zero (0) for Daily schedules. DaysInterval specified is '{0}'.
     WeeksIntervalError = WeeksInterval must be greater than zero (0) for Weekly schedules. WeeksInterval specified is '{0}'.

--- a/Examples/xScheduledTask/11-DisableABuiltInTask.ps1
+++ b/Examples/xScheduledTask/11-DisableABuiltInTask.ps1
@@ -1,0 +1,31 @@
+<#
+    .EXAMPLE
+    This example disables the built-in scheduled task called
+    'CreateExplorerShellUnelevatedTask'.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential
+    )
+
+    Import-DscResource -ModuleName xComputerManagement
+
+    Node $NodeName
+    {
+        xScheduledTask DisableCreateExplorerShellUnelevatedTask
+        {
+            TaskName            = 'CreateExplorerShellUnelevatedTask'
+            TaskPath            = '\'
+            Enable              = $false
+        }
+    }
+}

--- a/Examples/xScheduledTask/11-DisableABuiltInTask.ps1
+++ b/Examples/xScheduledTask/11-DisableABuiltInTask.ps1
@@ -9,12 +9,7 @@ Configuration Example
     (
         [Parameter()]
         [System.String[]]
-        $NodeName = 'localhost',
-
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential]
-        $Credential
+        $NodeName = 'localhost'
     )
 
     Import-DscResource -ModuleName xComputerManagement

--- a/Examples/xScheduledTask/12-DeleteABuiltInTask.ps1
+++ b/Examples/xScheduledTask/12-DeleteABuiltInTask.ps1
@@ -1,0 +1,31 @@
+<#
+    .EXAMPLE
+    This example deletes the built-in scheduled task called
+    'CreateExplorerShellUnelevatedTask'.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential
+    )
+
+    Import-DscResource -ModuleName xComputerManagement
+
+    Node $NodeName
+    {
+        xScheduledTask DeleteCreateExplorerShellUnelevatedTask
+        {
+            TaskName            = 'CreateExplorerShellUnelevatedTask'
+            TaskPath            = '\'
+            Ensure              = 'Absent'
+        }
+    }
+}

--- a/Examples/xScheduledTask/12-DeleteABuiltInTask.ps1
+++ b/Examples/xScheduledTask/12-DeleteABuiltInTask.ps1
@@ -9,12 +9,7 @@ Configuration Example
     (
         [Parameter()]
         [System.String[]]
-        $NodeName = 'localhost',
-
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential]
-        $Credential
+        $NodeName = 'localhost'
     )
 
     Import-DscResource -ModuleName xComputerManagement

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ xScheduledTask has the following properties:
 * [Run a PowerShell script once as a specified user with highest privileges](/Examples/xScheduledTask/9-RunPowerShellTaskOnceAsUserWithHighestPriveleges.ps1)
 * [Run a PowerShell script once as a specified user only when the user is logged on](/Examples/xScheduledTask/10-RunPowerShellTaskOnceAsUserInteractiveOnly.ps1)
 * [Disable a built-in scheduled task](/Examples/xScheduledTask/11-DisableABuiltInTask.ps1)
+* [Delete a built-in scheduled task](/Examples/xScheduledTask/12-DeleteABuiltInTask.ps1)
 
 ## xPowerPlan
 
@@ -219,12 +220,13 @@ xVirtualMemory has the following properties:
 ### Unreleased
 
 * BREAKING CHANGE: xScheduledTask:
-  * Add support to disable built-in scheduled tasks - See [Issue #74](https://github.com/PowerShell/xComputerManagement/issues/74).
   * Breaking change because `Get-TargetResource` no longer outputs
     `ActionExecutable` and `ScheduleType` properties when the scheduled
     task does not exist. It will also include `TaskPath` in output when
     scheduled task does not exist.
 * xScheduledTask:
+  * Add support to disable built-in scheduled tasks - See [Issue #74](https://github.com/PowerShell/xComputerManagement/issues/74).
+  * Fix unit test mocked schedule task object structure.
   * Fix error message when trigger type is unknown - See [Issue #121](https://github.com/PowerShell/xComputerManagement/issues/121).
   * Moved strings into separate strings file.
   * Updated to meet HQRM guidelines.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ xVirtualMemory has the following properties:
 
 ### Unreleased
 
+* BREAKING CHANGE: xScheduledTask:
+  * Add support to disable built-in scheduled tasks - See [Issue #74](https://github.com/PowerShell/xComputerManagement/issues/74).
+  * Breaking change because `Get-TargetResource` no longer outputs
+    `ActionExecutable` and `ScheduleType` properties when the scheduled
+    task does not exist. It will also include `TaskPath` in output when
+    scheduled task does not exist.
 * xScheduledTask:
   * Fix error message when trigger type is unknown - See [Issue #121](https://github.com/PowerShell/xComputerManagement/issues/121).
   * Moved strings into separate strings file.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ xScheduledTask has the following properties:
 * [Run a PowerShell script every 15 minutes indefinitely on a server](/Examples/xScheduledTask/8-RunPowerShellTaskEvery15MinutesIndefinitely.ps1)
 * [Run a PowerShell script once as a specified user with highest privileges](/Examples/xScheduledTask/9-RunPowerShellTaskOnceAsUserWithHighestPriveleges.ps1)
 * [Run a PowerShell script once as a specified user only when the user is logged on](/Examples/xScheduledTask/10-RunPowerShellTaskOnceAsUserInteractiveOnly.ps1)
+* [Disable a built-in scheduled task](/Examples/xScheduledTask/11-DisableABuiltInTask.ps1)
 
 ## xPowerPlan
 

--- a/Tests/Integration/MSFT_xScheduledTask.Config.ps1
+++ b/Tests/Integration/MSFT_xScheduledTask.Config.ps1
@@ -424,3 +424,31 @@ Configuration xScheduledTaskExecuteAsDel
         }
     }
 }
+
+Configuration xScheduledTaskDisableBuiltIn
+{
+    Import-DscResource -ModuleName xComputerManagement
+    node 'localhost'
+    {
+        xScheduledTask xScheduledTaskDisableBuiltIn
+        {
+            TaskName              = 'Test task builtin'
+            TaskPath              = '\xComputerManagement\'
+            Enable                = $false
+        }
+    }
+}
+
+Configuration xScheduledTaskRemoveBuiltIn
+{
+    Import-DscResource -ModuleName xComputerManagement
+    node 'localhost'
+    {
+        xScheduledTask xScheduledTaskRemoveBuiltIn
+        {
+            TaskName              = 'Test task builtin'
+            TaskPath              = '\xComputerManagement\'
+            Ensure                = 'Absent'
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xScheduledTask.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScheduledTask.Integration.Tests.ps1
@@ -198,9 +198,9 @@ try
         $action = New-ScheduledTaskAction -Execute 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
         $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date)
         $task = New-ScheduledTask -Action $action -Trigger $trigger
-        Register-ScheduledTask -InputObject $task -TaskName 'Test task builtin' -TaskPath = '\xComputerManagement\'
+        Register-ScheduledTask -InputObject $task -TaskName 'Test task builtin' -TaskPath '\xComputerManagement\' -User 'NT AUTHORITY\SYSTEM'
 
-        Context "Built-in task needs to be disabled" {
+        Context 'Built-in task needs to be disabled' {
             $currentConfig = 'xScheduledTaskDisableBuiltIn'
             $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
             $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
@@ -229,14 +229,16 @@ try
             }
 
             It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration   | Where-Object {$_.ConfigurationName -eq $currentConfig}
+                $current = Get-DscConfiguration   | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $currentConfig
+                }
                 $current.TaskName              | Should -Be 'Test task builtin'
                 $current.TaskPath              | Should -Be '\xComputerManagement\'
                 $current.Enable                | Should -Be $false
             }
         }
 
-        Context "Built-in task needs to be removed" {
+        Context 'Built-in task needs to be removed' {
             $currentConfig = 'xScheduledTaskRemoveBuiltIn'
             $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
             $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
@@ -266,7 +268,9 @@ try
             }
 
             It 'Should have set the resource and all the parameters should match' {
-                $current = Get-DscConfiguration   | Where-Object {$_.ConfigurationName -eq $currentConfig}
+                $current = Get-DscConfiguration   | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $currentConfig
+                }
                 $current.TaskName              | Should -Be 'Test task builtin'
                 $current.TaskPath              | Should -Be '\xComputerManagement\'
                 $current.Ensure                | Should -Be 'Absent'

--- a/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
@@ -37,7 +37,9 @@ try
         # Function to allow mocking pipeline input
         function Register-ScheduledTask
         {
-            param (
+            param
+            (
+                [Parameter()]
                 [switch]
                 $Force,
 
@@ -80,7 +82,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask { return $null }
+                Mock -CommandName Get-ScheduledTask -MockWith { return $null }
 
                 It 'Should return the correct values from Get-TargetResource' {
                     $result = Get-TargetResource @testParameters
@@ -108,7 +110,8 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask { return @{
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
                         Actions   = @(@{
@@ -151,7 +154,8 @@ try
                     Verbose  = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask { return @{
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
                         TaskName = $testParameters.TaskName
                         TaskPath = $testParameters.TaskPath
                         Actions  = [pscustomobject] @{
@@ -195,7 +199,7 @@ try
                     Verbose  = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName = $testParameters.TaskName
                         TaskPath = $testParameters.TaskPath
@@ -247,7 +251,7 @@ try
                     Verbose          = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask { return $null }
+                Mock -CommandName Get-ScheduledTask
 
                 It 'Should return the correct values from Get-TargetResource' {
                     $result = Get-TargetResource @testParameters
@@ -270,7 +274,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -323,7 +327,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -370,7 +374,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -423,7 +427,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -469,7 +473,7 @@ try
                     Verbose          = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -521,7 +525,7 @@ try
                     Verbose          = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -566,7 +570,7 @@ try
                     Verbose             = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -621,7 +625,7 @@ try
                     Verbose             = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -678,7 +682,7 @@ try
                     Verbose             = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -734,7 +738,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -789,7 +793,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -844,7 +848,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -904,7 +908,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -968,7 +972,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1027,7 +1031,8 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask { return @{
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
                         Actions   = @(
@@ -1078,7 +1083,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1135,7 +1140,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1213,7 +1218,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1281,7 +1286,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1344,7 +1349,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1357,7 +1362,7 @@ try
                         Triggers  = @(
                             [pscustomobject] @{
                                 Repetition = @{
-                                    Duration = "PT4H"
+                                    Duration = 'PT4H'
                                     Interval = "PT$([System.TimeSpan]::Parse($testParameters.RepeatInterval).TotalMinutes)M"
                                 }
                                 CimClass   = @{
@@ -1398,7 +1403,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1411,7 +1416,7 @@ try
                         Triggers  = @(
                             [pscustomobject] @{
                                 Repetition = @{
-                                    Duration = ""
+                                    Duration = ''
                                     Interval = "PT$([System.TimeSpan]::Parse($testParameters.RepeatInterval).TotalMinutes)M"
                                 }
                                 CimClass   = @{
@@ -1452,7 +1457,7 @@ try
                     Verbose            = $True
                 }
 
-                Mock -CommandName Get-ScheduledTask {
+                Mock -CommandName Get-ScheduledTask -MockWith {
                     @{
                         TaskName  = $testParameters.TaskName
                         TaskPath  = $testParameters.TaskPath
@@ -1465,7 +1470,7 @@ try
                         Triggers  = @(
                             [pscustomobject] @{
                                 Repetition = @{
-                                    Duration = ""
+                                    Duration = ''
                                     Interval = "PT$([System.TimeSpan]::Parse($testParameters.RepeatInterval).TotalMinutes)M"
                                 }
                                 CimClass   = @{

--- a/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_xScheduledTask.Tests.ps1
@@ -115,6 +115,94 @@ try
                 }
             }
 
+            Context 'A built-in scheduled task exists and is enabled, but it should be disabled' {
+                $testParameters = @{
+                    TaskName = 'Test task'
+                    TaskPath = '\Test\'
+                    Enable = $false
+                    Verbose = $True
+                }
+
+                Mock -CommandName Get-ScheduledTask { return @{
+                        TaskName = $testParameters.TaskName
+                        TaskPath = $testParameters.TaskPath
+                        Actions = @(@{
+                                Execute = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                            })
+                        Triggers = @(@{
+                                Repetition = @{
+                                    Duration = "PT15M"
+                                    Interval = "PT15M"
+                                }
+                                CimClass = @{
+                                    CimClassName = 'MSFT_TaskTimeTrigger'
+                                }
+                            })
+                        Settings = @(@{
+                            Enabled = $true
+                        })
+                    } }
+
+                It 'Should return the correct values from Get-TargetResource' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Enable | Should -Be $true
+                    $result.Ensure | Should -Be 'Present'
+                }
+
+                It 'Should return false from the test method' {
+                    Test-TargetResource @testParameters | Should -Be $false
+                }
+
+                It 'Should remove the scheduled task in the set method' {
+                    Set-TargetResource @testParameters
+                    Assert-MockCalled Register-ScheduledTask -Exactly -Times 1
+                }
+            }
+
+            Context 'A built-in scheduled task exists, but it should be absent' {
+                $testParameters = @{
+                    TaskName = 'Test task'
+                    TaskPath = '\Test\'
+                    Ensure = 'Absent'
+                    Verbose = $True
+                }
+
+                Mock -CommandName Get-ScheduledTask { return @{
+                        TaskName = $testParameters.TaskName
+                        TaskPath = $testParameters.TaskPath
+                        Actions = @(@{
+                                Execute = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                            })
+                        Triggers = @(@{
+                                Repetition = @{
+                                    Duration = "PT15M"
+                                    Interval = "PT15M"
+                                }
+                                CimClass = @{
+                                    CimClassName = 'MSFT_TaskTimeTrigger'
+                                }
+                            })
+                        Settings = @(@{
+                            Enabled = $true
+                        })
+                    } }
+
+                It 'Should return the correct values from Get-TargetResource' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Enable | Should -Be $true
+                    $result.Ensure | Should -Be 'Present'
+                }
+
+                It 'Should return false from the test method' {
+                    Test-TargetResource @testParameters | Should -Be $false
+                }
+
+                It 'Should remove the scheduled task in the set method' {
+                    Set-TargetResource @testParameters
+                    Assert-MockCalled Unregister-ScheduledTask -Exactly -Times 1
+                }
+            }
+
             Context 'A scheduled task doesnt exist, and it should not' {
                 $testParameters = @{
                     TaskName = 'Test task'


### PR DESCRIPTION
**Pull Request (PR) description**
* xScheduledTask:
  * Add support to disable built-in scheduled tasks - See [Issue #74](https://github.com/PowerShell/xComputerManagement/issues/74).
  * Fix unit test mocked schedule task object structure.
* BREAKING CHANGE: xScheduledTask:
  * Breaking change because `Get-TargetResource` no longer outputs
    `ActionExecutable` and `ScheduleType` properties when the scheduled
    task does not exist. It will also include `TaskPath` in output when
    scheduled task does not exist.

**This Pull Request (PR) fixes the following issues:**
- Fixes #74

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - as always would you be able to review for me? I cleaned up the unit tests hashtable layouts because I figured you'd pick up on the incorrect style :grin: - so sorry about the large number of style corrections in the unit tests file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/132)
<!-- Reviewable:end -->
