### PR TITLE
xScheduledTask - Fix deletion of scheduled task with unknown or empty task trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Unreleased
 
 - Fix master branch AppVeyor badge link URL in README.MD - See [Issue #140](https://github.com/PowerShell/xComputerManagement/issues/140).
-- Fix deletion of scheduled task with unknown or empty task trigger :
-  - Get-TargetResource returns an empty ScheduleType string if the task trigger is empty or unknown 
-  - See [Issue #137](https://github.com/PowerShell/xComputerManagement/issues/137).
+- Fix deletion of scheduled task with unknown or empty task trigger.
+  Get-TargetResource returns an empty ScheduleType string if the task
+  trigger is empty or unknown - See [Issue
+  #137](https://github.com/PowerShell/xComputerManagement/issues/137).
 
 ## 4.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix master branch AppVeyor badge link URL in README.MD - See [Issue #140](https://github.com/PowerShell/xComputerManagement/issues/140).
+- Fix deletion of scheduled task with unknown or empty task trigger. Get-TargetResource returns an empty ScheduleType string if the task trigger is empty or unknown - See [Issue #137](https://github.com/PowerShell/xComputerManagement/issues/137)
 
 ## 4.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Fix master branch AppVeyor badge link URL in README.MD - See [Issue #140](https://github.com/PowerShell/xComputerManagement/issues/140).
-- Fix deletion of scheduled task with unknown or empty task trigger. Get-TargetResource returns an empty ScheduleType string if the task trigger is empty or unknown - See [Issue #137](https://github.com/PowerShell/xComputerManagement/issues/137)
+- Fix deletion of scheduled task with unknown or empty task trigger :
+  - Get-TargetResource returns an empty ScheduleType string if the task trigger is empty or unknown 
+  - See [Issue #137](https://github.com/PowerShell/xComputerManagement/issues/137).
 
 ## 4.0.0.0
 

--- a/Modules/xComputerManagement/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/Modules/xComputerManagement/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -439,6 +439,7 @@ function Get-TargetResource
             default
             {
                 $returnScheduleType = ''
+                Write-Verbose -Message ($script:localizedData.TriggerTypeUnknown -f $trigger.CimClass.CimClassName)
             }
         }
 

--- a/Modules/xComputerManagement/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
+++ b/Modules/xComputerManagement/DSCResources/MSFT_xScheduledTask/MSFT_xScheduledTask.psm1
@@ -438,9 +438,7 @@ function Get-TargetResource
 
             default
             {
-                New-InvalidArgumentException `
-                    -Message ($script:localizedData.TriggerTypeError -f $trigger.CimClass.CimClassName) `
-                    -ArgumentName CimClassName
+                $returnScheduleType = ''
             }
         }
 

--- a/Modules/xComputerManagement/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
+++ b/Modules/xComputerManagement/DSCResources/MSFT_xScheduledTask/en-US/MSFT_xScheduledTask.strings.psd1
@@ -2,7 +2,7 @@ ConvertFrom-StringData @'
     GetScheduledTaskMessage = Getting scheduled task '{0}' in '{1}'.
     TaskNotFoundMessage = Task '{0}' not found in '{1}'. Returning an empty task with Ensure = "Absent".
     TaskFoundMessage = Task '{0}' found in '{1}'. Retrieving settings, first action, first trigger and repetition settings.
-    TriggerTypeError = Trigger type '{0}' not recognized.
+    TriggerTypeUnknown = Trigger type '{0}' not recognized.
     DetectedScheduleTypeMessage = Detected schedule type '{0}' for first trigger.
     SetScheduledTaskMessage = Setting scheduled task '{0}' in '{1}'.
     DisablingExistingScheduledTask = Disabling existing scheduled task '{0}' in '{1}'.


### PR DESCRIPTION
**Pull Request (PR) description**
Fixes deletion of scheduled task with unknown or empty task trigger. Get-TargetResource now returns an empty ScheduleType string if the task trigger is empty or unknown instead of throwing an error.

Tasks like Microsoft\Windows\Application Experience\ProgramDataUpdater don't have a valid ScheduleType for the xScheduledTask DSC resource. 

Throwing an error in the Get function is not needed in this case as results of the Get function will be compared with desired state values in the Test function. The empty ScheduledType string will be compared to one the `[ValidateSet('Once', 'Daily', 'Weekly', 'AtStartup', 'AtLogOn')]` mandatory values of  the ScheduledType parameter. The result of the Test function will then be `$false` and the Set function called to either correct the missing/bad ScheduledType if `$ensure='present'` or to delete the scheduled task if `$ensure='absent'`

**This Pull Request (PR) fixes the following issues:**
Fixes issue #137 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcomputermanagement/142)
<!-- Reviewable:end -->
