### PR TITLE
Computer: Remove deletion of AD computer object when using PasswordPass and UnsecuredJoin options or JoinReadOnly option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove deletion of computer object when PasswordPass and UnsecuredJoin options are used in DSC_Computer.
+  Fixes [Issue #446](https://github.com/dsccommunity/ComputerManagementDsc/issues/446).
+
 ## [10.0.0] - 2025-01-25
 
 ### Added

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -268,7 +268,8 @@ function Set-TargetResource
                 {
                     # UnsecuredJoin and PasswordPass options or JoinReadOnly option uses an existing machine account
                     # to join the computer to the domain and should not be deleted before.
-                    if ( -not (($Options -contains 'PasswordPass' -and $options -contains 'UnsecuredJoin') -or ($Options -contains 'JoinReadOnly'))) {
+                    if ( -not (($Options -contains 'PasswordPass' -and $options -contains 'UnsecuredJoin') -or ($Options -contains 'JoinReadOnly')))
+                    {
                         Remove-ADSIObject -Path $computerObject.Path -Credential $Credential
                         Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f $Name, $computerObject.Path)
                     }
@@ -276,7 +277,8 @@ function Set-TargetResource
                 else
                 {
                     # Check if the computer object exists in the domain when using UnsecuredJoin and PasswordPass options or JoinReadOnly option 
-                    if (($Options -contains 'PasswordPass' -and $options -contains 'UnsecuredJoin') -or ($Options -contains 'JoinReadOnly')) {
+                    if (($Options -contains 'PasswordPass' -and $options -contains 'UnsecuredJoin') -or ($Options -contains 'JoinReadOnly'))
+                    {
                         $errorMessage = $script:localizedData.ComputerObjectNotFound -f $Name,$DomainName
                         New-ObjectNotFoundException -Message $errorMessage
                     }

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -262,13 +262,18 @@ function Set-TargetResource
                     $addComputerParameters.Add("Server", $Server)
                 }
 
-                # Check for existing computer objecst using ADSI without ActiveDirectory module
-                $computerObject = Get-ADSIComputer -Name $Name -DomainName $DomainName -Credential $Credential
+                # When using the UnsecuredJoin and PasswordPass options means the computer object
+                # has been precreated in the domain and should not be deleted before joining the domain.
+                if ( -not ($Options -contains 'PasswordPass' -and
+                $options -contains 'UnsecuredJoin')) {
+                    # Check for existing computer objecst using ADSI without ActiveDirectory module
+                    $computerObject = Get-ADSIComputer -Name $Name -DomainName $DomainName -Credential $Credential
 
-                if ($computerObject)
-                {
-                    Remove-ADSIObject -Path $computerObject.Path -Credential $Credential
-                    Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f $Name, $computerObject.Path)
+                    if ($computerObject)
+                    {
+                        Remove-ADSIObject -Path $computerObject.Path -Credential $Credential
+                        Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f $Name, $computerObject.Path)
+                    }
                 }
 
                 if (-not [System.String]::IsNullOrEmpty($Options))

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -262,17 +262,23 @@ function Set-TargetResource
                     $addComputerParameters.Add("Server", $Server)
                 }
 
-                # When using the UnsecuredJoin and PasswordPass options means the computer object
-                # has been precreated in the domain and should not be deleted before joining the domain.
-                if ( -not ($Options -contains 'PasswordPass' -and
-                $options -contains 'UnsecuredJoin')) {
-                    # Check for existing computer objecst using ADSI without ActiveDirectory module
-                    $computerObject = Get-ADSIComputer -Name $Name -DomainName $DomainName -Credential $Credential
-
-                    if ($computerObject)
-                    {
+                # Check for existing computer objecst using ADSI without ActiveDirectory module
+                $computerObject = Get-ADSIComputer -Name $Name -DomainName $DomainName -Credential $Credential
+                if ($computerObject)
+                {
+                    # UnsecuredJoin and PasswordPass options or JoinReadOnly option uses an existing machine account
+                    # to join the computer to the domain and should not be deleted before.
+                    if ( -not (($Options -contains 'PasswordPass' -and $options -contains 'UnsecuredJoin') -or ($Options -contains 'JoinReadOnly'))) {
                         Remove-ADSIObject -Path $computerObject.Path -Credential $Credential
                         Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f $Name, $computerObject.Path)
+                    }
+                }
+                else
+                {
+                    # Check if the computer object exists in the domain when using UnsecuredJoin and PasswordPass options or JoinReadOnly option 
+                    if (($Options -contains 'PasswordPass' -and $options -contains 'UnsecuredJoin') -or ($Options -contains 'JoinReadOnly')) {
+                        $errorMessage = $script:localizedData.ComputerObjectNotFound -f $Name,$DomainName
+                        New-ObjectNotFoundException -Message $errorMessage
                     }
                 }
 

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -262,7 +262,7 @@ function Set-TargetResource
                     $addComputerParameters.Add("Server", $Server)
                 }
 
-                # Check for existing computer objecst using ADSI without ActiveDirectory module
+                # Check for existing computer object using ADSI without ActiveDirectory module
                 $computerObject = Get-ADSIComputer -Name $Name -DomainName $DomainName -Credential $Credential
                 if ($computerObject)
                 {

--- a/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
+++ b/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
@@ -17,6 +17,7 @@ ConvertFrom-StringData @'
     DomainNameAndWorkgroupNameError = Only DomainName or WorkGroupName can be specified at once.
     ComputerNotInDomainMessage = This machine is not a domain member.
     DeletedExistingComputerObject = Deleted existing computer object with name '{0}' at path '{1}'.
+    ComputerObjectNotFound = Computer object with name '{0}' not found in domain '{1}'.
     InvalidOptionPasswordPassUnsecuredJoin = Domain Join option 'PasswordPass' may not be specified if 'UnsecuredJoin' is specified.
     InvalidOptionCredentialUnsecuredJoinNullUsername = 'Credential' username must be null if 'UnsecuredJoin' is specified.
 '@


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->

#### Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR.
    Also, make sure you have updated the CHANGELOG.md, see the
    task list below. An entry in the CHANGELOG.md is mandatory
    for all PRs.
-->

When using PasswordPass and UnsecuredJoin options or JoinReadOnly option means AD computer object has been pre-created within Active Directory prior to domain join and should not be deleted

#### This Pull Request (PR) fixes the following issues

<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list of the issues using a GitHub closing keyword, e.g.:

- Fixes #123
- Fixes #124
-->
- Fixes #446 
#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ComputerManagementDsc/447)
<!-- Reviewable:end -->
